### PR TITLE
feat: public booking page at GET /book/{slug}

### DIFF
--- a/documentation/diagrams/Container.md
+++ b/documentation/diagrams/Container.md
@@ -4,6 +4,8 @@ C4 Container Diagram
 
 > Phase 2a (implemented): EventTypes + booking. Config (settings, event types, connected calendars) in H2; bookings written to the calendar via the CalendarWriter port. Real Google calendar + host auth are later slices.
 
+> Phase 2c (implemented): public booking page at `GET /book/{slug}` — a self-contained HTML/JS page (attendee timezone; 1-day mobile / 7-day desktop) driving the booking JSON API. (Host admin Telegram bot and deployment are separate, later.)
+
 ```mermaid
 C4Container
 title C4 Container Diagram

--- a/time-matcher/src/main/kotlin/io/vladar107/Application.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/Application.kt
@@ -8,6 +8,7 @@ import io.vladar107.web.plugins.configureSerialization
 import io.vladar107.web.plugins.configureStatusPages
 import io.vladar107.web.availability.configureAvailability
 import io.vladar107.web.booking.configureBooking
+import io.vladar107.web.booking.configureBookingPage
 import io.vladar107.web.booking.configureEventTypes
 import io.vladar107.web.user.configureUser
 
@@ -25,4 +26,5 @@ fun Application.module() {
     configureAvailability()
     configureEventTypes()
     configureBooking()
+    configureBookingPage()
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/booking/BookingPageController.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/booking/BookingPageController.kt
@@ -1,0 +1,17 @@
+package io.vladar107.web.booking
+
+import io.ktor.http.ContentType
+import io.ktor.server.application.Application
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+fun Application.configureBookingPage() {
+    val html = (object {}.javaClass.getResource("/web/booking.html")
+        ?: error("web/booking.html not found on classpath")).readText()
+    routing {
+        get("/book/{slug}") {
+            call.respondText(html, ContentType.Text.Html)
+        }
+    }
+}

--- a/time-matcher/src/main/resources/web/booking.html
+++ b/time-matcher/src/main/resources/web/booking.html
@@ -131,15 +131,20 @@ el('bookForm').addEventListener('submit', async (ev) => {
     if (r.status === 201){
       const c = await r.json();
       el('formCard').classList.add('hidden'); el('done').classList.remove('hidden');
-      el('done').innerHTML = '<div class="ok"><strong>Booked!</strong></div><div>' + c.eventType +
-        ' on ' + new Date(c.start).toLocaleString([], {dateStyle:'full', timeStyle:'short'}) + ' (' + tz +
-        ')</div><div class="muted">A calendar invite is on its way to ' + el('email').value + '.</div>';
+      el('done').replaceChildren();
+      const ok = document.createElement('div'); ok.className = 'ok';
+      const okStrong = document.createElement('strong'); okStrong.textContent = 'Booked!'; ok.appendChild(okStrong);
+      const detail = document.createElement('div');
+      detail.textContent = c.eventType + ' on ' + new Date(c.start).toLocaleString([], {dateStyle:'full', timeStyle:'short'}) + ' (' + tz + ')';
+      const inv = document.createElement('div'); inv.className = 'muted';
+      inv.textContent = 'A calendar invite is on its way to ' + el('email').value + '.';
+      el('done').append(ok, detail, inv);
       return;
     }
     if (r.status === 409){ el('formMsg').innerHTML = '<span class="error">That time was just taken — please pick another.</span>'; el('formCard').classList.add('hidden'); chosenStart = null; loadSlots(); return; }
     if (r.status === 404){ el('formMsg').innerHTML = '<span class="error">Event type not found.</span>'; return; }
     if (r.status === 502){ el('formMsg').innerHTML = '<span class="error">Calendar temporarily unavailable — try again.</span>'; return; }
-    const t = await r.text(); el('formMsg').innerHTML = '<span class="error">' + (t || 'Could not book.') + '</span>';
+    const t = await r.text(); el('formMsg').replaceChildren(); const span = document.createElement('span'); span.className = 'error'; span.textContent = t || 'Could not book.'; el('formMsg').appendChild(span);
   } catch(e){ el('formMsg').innerHTML = '<span class="error">Network error — try again.</span>'; }
   finally { el('submitBtn').disabled = false; }
 });

--- a/time-matcher/src/main/resources/web/booking.html
+++ b/time-matcher/src/main/resources/web/booking.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Book a meeting</title>
+<style>
+  :root { --fg:#1a1a2e; --muted:#6b7280; --accent:#2563eb; --bg:#f7f7fb; --card:#fff; --border:#e5e7eb; }
+  * { box-sizing: border-box; }
+  body { margin:0; font-family: system-ui, -apple-system, sans-serif; color:var(--fg); background:var(--bg); }
+  .wrap { max-width: 900px; margin: 0 auto; padding: 24px 16px; }
+  h1 { font-size: 1.4rem; margin: 0 0 4px; }
+  .muted { color: var(--muted); font-size: .9rem; }
+  .card { background:var(--card); border:1px solid var(--border); border-radius:12px; padding:16px; margin-top:16px; }
+  .nav { display:flex; align-items:center; justify-content:space-between; gap:8px; margin-bottom:12px; }
+  button { font:inherit; cursor:pointer; border-radius:8px; border:1px solid var(--border); background:#fff; padding:8px 12px; }
+  button.primary { background:var(--accent); color:#fff; border-color:var(--accent); }
+  button:disabled { opacity:.5; cursor:default; }
+  .days { display:grid; gap:12px; grid-template-columns: 1fr; }
+  .days.week { grid-template-columns: repeat(7, 1fr); }
+  .day h3 { font-size:.85rem; margin:0 0 8px; }
+  .slots { display:flex; flex-direction:column; gap:6px; }
+  .slot { text-align:center; }
+  .slot.selected { background:var(--accent); color:#fff; border-color:var(--accent); }
+  form { display:flex; flex-direction:column; gap:10px; max-width:360px; }
+  input { font:inherit; padding:8px; border:1px solid var(--border); border-radius:8px; }
+  .hidden { display:none; }
+  .error { color:#b91c1c; } .ok { color:#047857; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div id="header"><h1 id="title">Loading…</h1><div class="muted" id="subtitle"></div></div>
+  <div id="notfound" class="card hidden"><strong>Event type not found.</strong> Check the link.</div>
+  <div id="picker" class="card hidden">
+    <div class="nav"><button id="prev">‹ Prev</button><div class="muted" id="rangeLabel"></div><button id="next">Next ›</button></div>
+    <div class="muted" id="tzLabel"></div>
+    <div id="days" class="days"></div>
+    <div id="slotsMsg" class="muted"></div>
+  </div>
+  <div id="formCard" class="card hidden">
+    <div id="chosen" class="muted"></div>
+    <form id="bookForm">
+      <input id="name" placeholder="Your name" required>
+      <input id="email" type="email" placeholder="Your email" required>
+      <button class="primary" type="submit" id="submitBtn">Confirm booking</button>
+      <div id="formMsg"></div>
+    </form>
+  </div>
+  <div id="done" class="card hidden"></div>
+</div>
+<script>
+const slug = location.pathname.split('/').filter(Boolean).pop();
+const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const el = id => document.getElementById(id);
+let wide = window.matchMedia('(min-width: 700px)').matches;
+let viewStart = startOfDay(new Date());
+let chosenStart = null;
+
+function startOfDay(d){ return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
+function addDays(d, n){ return new Date(d.getFullYear(), d.getMonth(), d.getDate()+n); }
+function fmtTime(iso){ return new Date(iso).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}); }
+function fmtDay(d){ return d.toLocaleDateString([], {weekday:'short', month:'short', day:'numeric'}); }
+function dayKey(d){ return d.getFullYear()+'-'+d.getMonth()+'-'+d.getDate(); }
+function windowDays(){ return wide ? 7 : 1; }
+
+async function loadEventType(){
+  const r = await fetch('/event-types/' + encodeURIComponent(slug));
+  if (r.status === 404){ el('title').textContent = 'Not available'; el('notfound').classList.remove('hidden'); return false; }
+  if (!r.ok){ el('title').textContent = 'Temporarily unavailable'; return false; }
+  const et = await r.json();
+  el('title').textContent = et.name;
+  el('subtitle').textContent = et.durationMinutes + ' min';
+  return true;
+}
+
+async function loadSlots(){
+  el('tzLabel').textContent = 'Times shown in ' + tz;
+  const n = windowDays();
+  const from = viewStart, to = addDays(viewStart, n);
+  el('rangeLabel').textContent = n === 1 ? fmtDay(from) : (fmtDay(from) + ' – ' + fmtDay(addDays(from, n-1)));
+  el('days').className = 'days' + (wide ? ' week' : '');
+  el('days').innerHTML = ''; el('slotsMsg').textContent = 'Loading…';
+  let slots = [];
+  try {
+    const r = await fetch('/book/' + encodeURIComponent(slug) + '/slots?from=' + from.toISOString() + '&to=' + to.toISOString());
+    if (r.status === 404){ el('notfound').classList.remove('hidden'); el('picker').classList.add('hidden'); return; }
+    if (r.status === 502){ el('slotsMsg').textContent = 'Calendar temporarily unavailable — try again.'; return; }
+    if (!r.ok){ el('slotsMsg').textContent = 'Could not load times.'; return; }
+    slots = await r.json();
+  } catch(e){ el('slotsMsg').textContent = 'Could not load times.'; return; }
+  const byDay = {};
+  for (const s of slots){ const k = dayKey(new Date(s.start)); (byDay[k] = byDay[k] || []).push(s); }
+  for (let i=0; i<n; i++){
+    const d = addDays(from, i);
+    const col = document.createElement('div'); col.className = 'day';
+    const h = document.createElement('h3'); h.textContent = fmtDay(d); col.appendChild(h);
+    const list = document.createElement('div'); list.className = 'slots';
+    const daySlots = byDay[dayKey(d)] || [];
+    if (daySlots.length === 0){ const m = document.createElement('div'); m.className='muted'; m.textContent='—'; list.appendChild(m); }
+    for (const s of daySlots){
+      const b = document.createElement('button'); b.className='slot'; b.textContent = fmtTime(s.start);
+      b.onclick = () => choose(s.start, b); list.appendChild(b);
+    }
+    col.appendChild(list); el('days').appendChild(col);
+  }
+  el('slotsMsg').textContent = slots.length === 0 ? 'No times available in this range.' : '';
+}
+
+function choose(startIso, btn){
+  chosenStart = startIso;
+  document.querySelectorAll('.slot.selected').forEach(b => b.classList.remove('selected'));
+  btn.classList.add('selected');
+  el('chosen').textContent = 'Selected: ' + new Date(startIso).toLocaleString([], {dateStyle:'full', timeStyle:'short'}) + ' (' + tz + ')';
+  el('formCard').classList.remove('hidden'); el('done').classList.add('hidden'); el('formMsg').textContent = ''; el('name').focus();
+}
+
+el('prev').onclick = () => { viewStart = addDays(viewStart, -windowDays()); loadSlots(); };
+el('next').onclick = () => { viewStart = addDays(viewStart, windowDays()); loadSlots(); };
+window.matchMedia('(min-width: 700px)').addEventListener('change', e => { wide = e.matches; loadSlots(); });
+
+el('bookForm').addEventListener('submit', async (ev) => {
+  ev.preventDefault();
+  if (!chosenStart) return;
+  el('submitBtn').disabled = true; el('formMsg').textContent = '';
+  try {
+    const r = await fetch('/book/' + encodeURIComponent(slug), {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ attendeeName: el('name').value, attendeeEmail: el('email').value, start: chosenStart })
+    });
+    if (r.status === 201){
+      const c = await r.json();
+      el('formCard').classList.add('hidden'); el('done').classList.remove('hidden');
+      el('done').innerHTML = '<div class="ok"><strong>Booked!</strong></div><div>' + c.eventType +
+        ' on ' + new Date(c.start).toLocaleString([], {dateStyle:'full', timeStyle:'short'}) + ' (' + tz +
+        ')</div><div class="muted">A calendar invite is on its way to ' + el('email').value + '.</div>';
+      return;
+    }
+    if (r.status === 409){ el('formMsg').innerHTML = '<span class="error">That time was just taken — please pick another.</span>'; el('formCard').classList.add('hidden'); chosenStart = null; loadSlots(); return; }
+    if (r.status === 404){ el('formMsg').innerHTML = '<span class="error">Event type not found.</span>'; return; }
+    if (r.status === 502){ el('formMsg').innerHTML = '<span class="error">Calendar temporarily unavailable — try again.</span>'; return; }
+    const t = await r.text(); el('formMsg').innerHTML = '<span class="error">' + (t || 'Could not book.') + '</span>';
+  } catch(e){ el('formMsg').innerHTML = '<span class="error">Network error — try again.</span>'; }
+  finally { el('submitBtn').disabled = false; }
+});
+
+(async () => { if (await loadEventType()){ el('picker').classList.remove('hidden'); loadSlots(); } })();
+</script>
+</body>
+</html>

--- a/time-matcher/src/test/kotlin/io/vladar107/web/booking/BookingPageRoutesTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/web/booking/BookingPageRoutesTest.kt
@@ -1,0 +1,28 @@
+package io.vladar107.web.booking
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import io.vladar107.module
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BookingPageRoutesTest {
+    @Test fun servesBookingPageWiredToApi() = testApplication {
+        environment { config = MapApplicationConfig("db.url" to "jdbc:h2:mem:page-${UUID.randomUUID()};DB_CLOSE_DELAY=-1") }
+        application { module() }
+        val r = client.get("/book/intro")
+        assertEquals(HttpStatusCode.OK, r.status)
+        assertTrue(r.contentType()?.match(ContentType.Text.Html) == true, "expected text/html")
+        val body = r.bodyAsText()
+        assertTrue(body.contains("/event-types/"), "page should fetch the event type")
+        assertTrue(body.contains("/slots?from"), "page should fetch slots")
+        assertTrue(body.contains("/book/"), "page should POST a booking")
+    }
+}


### PR DESCRIPTION
## Phase 2c — Public booking page

Adds the attendee-facing booking page reachable by a shareable link. This is a pure web-layer addition that drives the already-built, already-tested booking JSON API — no new domain or application logic, no new dependencies.

### What's new
- **`GET /book/{slug}`** serves a self-contained HTML/CSS/vanilla-JS page (`src/main/resources/web/booking.html`), read once at wiring time and served verbatim. Coexists with the existing `GET /book/{slug}/slots` and `POST /book/{slug}` (distinct method/path).
- The page calls the existing endpoints: `GET /event-types/{slug}` (title + duration), `GET /book/{slug}/slots?from&to` (open slots), `POST /book/{slug}` (book).
- **Attendee's own timezone**: slots are displayed converted to the visitor's browser timezone; the booking submits the **exact instant string the slots API returned** — no client-side timezone math on submit, so there is zero ambiguity about which slot is booked.
- **Responsive date UX**: single-day view on small screens, 7-day week grid on large screens (`matchMedia('(min-width: 700px)')`).
- All result states handled: 201 confirmation, 409 "just taken" + slot refresh, 400 validation message, 404 not-found, 502 calendar-unavailable.

### Testing
- Integration test (`BookingPageRoutesTest`): `GET /book/{slug}` → 200, `text/html`, body wired to the three endpoints.
- The JS glue (fetch / timezone conversion / responsive render / submit) is not unit-tested in the JUnit harness — a headless-browser runner is out of scope for this slice and the residual manual-verification gap is explicit.
- Clean `./gradlew clean build` green.

### Reviewed
Whole-branch review: ready to merge, 0 Critical / 0 Important. An earlier XSS-hygiene issue (interpolating attendee/API data via `innerHTML`) was fixed by switching to `textContent`/DOM nodes; the remaining `innerHTML` uses are static literals only.

### Out of scope (later)
Host admin UI / Telegram bot · reschedule/cancel · branding · multi-event-type landing · auth · deployment.
