### PR TITLE
feat: host-admin Telegram bot — connect & manage Google Calendars (Phase 2d slice 1)

### DIFF
--- a/documentation/diagrams/Container.md
+++ b/documentation/diagrams/Container.md
@@ -6,6 +6,8 @@ C4 Container Diagram
 
 > Phase 2c (implemented): public booking page at `GET /book/{slug}` — a self-contained HTML/JS page (attendee timezone; 1-day mobile / 7-day desktop) driving the booking JSON API. (Host admin Telegram bot and deployment are separate, later.)
 
+> Phase 2d (implemented): host-only Telegram bot (long-polling) is the management surface — connect/list/remove Google Calendars and pick the booking target. Connecting uses a browser OAuth hop (`/oauth/google/start` → Google consent → `/oauth/google/callback`). Availability unions busy across all connected calendars; bookings write to the ★ target. (Event-type & schedule management via the bot, and deployment, are later.)
+
 ```mermaid
 C4Container
 title C4 Container Diagram

--- a/documentation/google-calendar-setup.md
+++ b/documentation/google-calendar-setup.md
@@ -36,7 +36,7 @@ This guide walks through the one-time steps to connect Time Matcher to your Goog
 
 1. Open Telegram and start a chat with [@BotFather](https://t.me/BotFather).
 2. Send `/newbot`, follow the prompts, and copy the **bot token** it gives you.
-3. Find your own Telegram user ID (e.g. via [@userinfobot](https://t.me/userinfobot)).
+3. Find your own Telegram user ID (e.g. via [@userinfobot](https://t.me/userinfobot)) — copy this number; you'll set it as `TELEGRAM_HOST_USER_ID` (step 6).
 
 ## 6. Run Time Matcher in Google Calendar mode
 

--- a/documentation/google-calendar-setup.md
+++ b/documentation/google-calendar-setup.md
@@ -20,27 +20,23 @@ This guide walks through the one-time steps to connect Time Matcher to your Goog
 4. Under **Test users**, click **Add users** and add your own Google account email. This lets you authenticate while the app is in "Testing" mode.
 5. Save and continue.
 
-## 4. Create an OAuth client (Desktop type)
+## 4. Create an OAuth client (Web application type)
 
 1. Go to **APIs & Services** → **Credentials**.
 2. Click **Create credentials** → **OAuth client ID**.
-3. Choose **Desktop app** as the application type. Give it a name and click **Create**.
-4. Copy the **Client ID** and **Client Secret** — you will need them in step 6.
-
-## 5. Get a refresh token via the OAuth Playground
-
-1. Open [OAuth 2.0 Playground](https://developers.google.com/oauthplayground/).
-2. Click the gear icon (⚙) in the top-right corner and check **Use your own OAuth credentials**.
-3. Enter your **Client ID** and **Client Secret** from step 4, then close the panel.
-4. In the **Step 1** box, find or type the scope:
+3. Choose **Web application** as the application type. Give it a name.
+4. Under **Authorized redirect URIs**, click **Add URI** and enter:
    ```
-   https://www.googleapis.com/auth/calendar
+   http://localhost:8080/oauth/google/callback
    ```
-   Click **Authorize APIs** and sign in with the Google account you added as a test user.
-5. In **Step 2**, click **Exchange authorization code for tokens**.
-6. Copy the **Refresh token** from the response — this is a long-lived credential.
+   (Adjust the base URL if deploying to a remote host.)
+5. Click **Create**. Copy the **Client ID** and **Client Secret** — you will need them below.
 
-> **Keep the refresh token secret.** Anyone with the client secret + refresh token can access your calendar.
+## 5. Create a Telegram bot with BotFather
+
+1. Open Telegram and start a chat with [@BotFather](https://t.me/BotFather).
+2. Send `/newbot`, follow the prompts, and copy the **bot token** it gives you.
+3. Find your own Telegram user ID (e.g. via [@userinfobot](https://t.me/userinfobot)).
 
 ## 6. Run Time Matcher in Google Calendar mode
 
@@ -50,11 +46,12 @@ Set the following environment variables before starting the server:
 CALENDAR_PROVIDER=google
 GOOGLE_CLIENT_ID=<your OAuth client ID>
 GOOGLE_CLIENT_SECRET=<your OAuth client secret>
-GOOGLE_REFRESH_TOKEN=<your refresh token>
-GOOGLE_CALENDAR_ID=primary
+OAUTH_REDIRECT_BASE_URL=http://localhost:8080
+TELEGRAM_BOT_TOKEN=<your bot token>
+TELEGRAM_HOST_USER_ID=<your Telegram user ID>
 ```
 
-`GOOGLE_CALENDAR_ID` defaults to `primary` if omitted. To use a different calendar, set it to the calendar's ID (visible in Google Calendar settings under "Integrate calendar").
+If none of the `GOOGLE_*` / `TELEGRAM_*` variables are set, the service starts in `inmemory` mode with no bot — no credentials required.
 
 ### How env vars map to `application.yaml`
 
@@ -67,11 +64,14 @@ calendar:
 google:
     clientId: "$GOOGLE_CLIENT_ID:"
     clientSecret: "$GOOGLE_CLIENT_SECRET:"
-    refreshToken: "$GOOGLE_REFRESH_TOKEN:"
-    calendarId: "$GOOGLE_CALENDAR_ID:primary"
-```
 
-If none of the variables are set, the service starts in `inmemory` mode (the default) — no Google credentials required.
+oauth:
+    redirectBaseUrl: "$OAUTH_REDIRECT_BASE_URL:http://localhost:8080"
+
+telegram:
+    botToken: "$TELEGRAM_BOT_TOKEN:"
+    hostUserId: "$TELEGRAM_HOST_USER_ID:0"
+```
 
 ### Example: start with env vars
 
@@ -79,7 +79,18 @@ If none of the variables are set, the service starts in `inmemory` mode (the def
 CALENDAR_PROVIDER=google \
 GOOGLE_CLIENT_ID=... \
 GOOGLE_CLIENT_SECRET=... \
-GOOGLE_REFRESH_TOKEN=... \
-GOOGLE_CALENDAR_ID=primary \
+OAUTH_REDIRECT_BASE_URL=http://localhost:8080 \
+TELEGRAM_BOT_TOKEN=... \
+TELEGRAM_HOST_USER_ID=... \
   ./gradlew run
 ```
+
+## 7. Connect via the bot
+
+Once the server is running with the Telegram env vars set:
+
+1. Open Telegram and DM your bot `/connect`.
+2. The bot replies with a link — tap it to open your browser.
+3. You will be redirected to Google's consent page. Approve access.
+4. After approval the browser redirects back to the server and the bot confirms the connection.
+5. To list or remove connected calendars, send `/calendars` to the bot.

--- a/time-matcher/src/main/kotlin/io/vladar107/Application.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/Application.kt
@@ -11,6 +11,7 @@ import io.vladar107.web.booking.configureBooking
 import io.vladar107.web.booking.configureBookingPage
 import io.vladar107.web.booking.configureEventTypes
 import io.vladar107.web.oauth.configureGoogleOAuth
+import io.vladar107.web.telegram.configureTelegramBot
 import io.vladar107.web.user.configureUser
 
 fun main(args: Array<String>) {
@@ -29,4 +30,5 @@ fun Application.module() {
     configureBooking()
     configureBookingPage()
     configureGoogleOAuth()
+    configureTelegramBot()
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/Application.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/Application.kt
@@ -10,6 +10,7 @@ import io.vladar107.web.availability.configureAvailability
 import io.vladar107.web.booking.configureBooking
 import io.vladar107.web.booking.configureBookingPage
 import io.vladar107.web.booking.configureEventTypes
+import io.vladar107.web.oauth.configureGoogleOAuth
 import io.vladar107.web.user.configureUser
 
 fun main(args: Array<String>) {
@@ -27,4 +28,5 @@ fun Application.module() {
     configureEventTypes()
     configureBooking()
     configureBookingPage()
+    configureGoogleOAuth()
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/application/availability/NoBookingCalendarException.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/application/availability/NoBookingCalendarException.kt
@@ -1,0 +1,4 @@
+package io.vladar107.application.availability
+
+/** No is_booking_target calendar is connected. Mapped to HTTP 503 at the web boundary. */
+class NoBookingCalendarException : RuntimeException("No booking calendar connected")

--- a/time-matcher/src/main/kotlin/io/vladar107/application/booking/ConnectedCalendarCommands.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/application/booking/ConnectedCalendarCommands.kt
@@ -1,0 +1,26 @@
+package io.vladar107.application.booking
+
+import io.vladar107.domain.booking.ConnectedCalendar
+import io.vladar107.infrastructure.Command
+import io.vladar107.infrastructure.CommandHandler
+import java.util.UUID
+
+data class ConnectGoogleCalendarCommand(val accountEmail: String, val externalCalendarId: String, val refreshToken: String) : Command<Unit>
+data class RemoveConnectedCalendarCommand(val id: UUID) : Command<Unit>
+data class SetBookingTargetCommand(val id: UUID) : Command<Unit>
+
+class ConnectGoogleCalendarCommandHandler(private val repo: ConnectedCalendarRepository) : CommandHandler<Unit, ConnectGoogleCalendarCommand> {
+    override suspend fun handle(command: ConnectGoogleCalendarCommand) {
+        val firstGoogle = repo.googleCalendars().isEmpty()
+        repo.add(ConnectedCalendar(UUID.randomUUID(), command.accountEmail, "GOOGLE",
+            command.accountEmail, command.externalCalendarId, command.refreshToken, isBookingTarget = firstGoogle))
+    }
+}
+
+class RemoveConnectedCalendarCommandHandler(private val repo: ConnectedCalendarRepository) : CommandHandler<Unit, RemoveConnectedCalendarCommand> {
+    override suspend fun handle(command: RemoveConnectedCalendarCommand) = repo.remove(command.id)
+}
+
+class SetBookingTargetCommandHandler(private val repo: ConnectedCalendarRepository) : CommandHandler<Unit, SetBookingTargetCommand> {
+    override suspend fun handle(command: SetBookingTargetCommand) = repo.setBookingTarget(command.id)
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/application/booking/ConnectedCalendarRepository.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/application/booking/ConnectedCalendarRepository.kt
@@ -2,4 +2,12 @@ package io.vladar107.application.booking
 
 import io.vladar107.domain.booking.ConnectedCalendar
 
-interface ConnectedCalendarRepository { suspend fun list(): List<ConnectedCalendar>; suspend fun default(): ConnectedCalendar }
+interface ConnectedCalendarRepository {
+    suspend fun list(): List<ConnectedCalendar>
+    suspend fun default(): ConnectedCalendar                // unchanged: first row (seeded IN_MEMORY)
+    suspend fun googleCalendars(): List<ConnectedCalendar>  // provider == "GOOGLE"
+    suspend fun bookingTarget(): ConnectedCalendar?         // the GOOGLE row with isBookingTarget == true
+    suspend fun add(calendar: ConnectedCalendar)
+    suspend fun remove(id: java.util.UUID)
+    suspend fun setBookingTarget(id: java.util.UUID)        // sets this GOOGLE row true, all other GOOGLE rows false
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/application/booking/ListConnectedCalendarsQuery.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/application/booking/ListConnectedCalendarsQuery.kt
@@ -1,0 +1,11 @@
+package io.vladar107.application.booking
+
+import io.vladar107.domain.booking.ConnectedCalendar
+import io.vladar107.infrastructure.Query
+import io.vladar107.infrastructure.QueryHandler
+
+class ListConnectedCalendarsQuery : Query<List<ConnectedCalendar>>
+
+class ListConnectedCalendarsQueryHandler(private val repo: ConnectedCalendarRepository) : QueryHandler<List<ConnectedCalendar>, ListConnectedCalendarsQuery> {
+    override suspend fun handle(query: ListConnectedCalendarsQuery): List<ConnectedCalendar> = repo.googleCalendars()
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarApi.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarApi.kt
@@ -28,13 +28,12 @@ import java.time.Instant
 @Serializable private data class EventInsertRequest(val summary: String, val start: EventTime, val end: EventTime, val attendees: List<EventAttendee> = emptyList())
 
 class GoogleCalendarApi(
-    private val tokenSource: GoogleTokenSource,
     private val httpClient: HttpClient,
 ) {
-    suspend fun freeBusy(calendarId: String, window: TimeInterval): List<TimeInterval> {
+    suspend fun freeBusy(accessToken: String, calendarId: String, window: TimeInterval): List<TimeInterval> {
         val resp = call {
             httpClient.post("https://www.googleapis.com/calendar/v3/freeBusy") {
-                header(HttpHeaders.Authorization, "Bearer ${tokenSource.accessToken()}")
+                header(HttpHeaders.Authorization, "Bearer $accessToken")
                 contentType(ContentType.Application.Json)
                 setBody(FreeBusyRequest(window.start.toString(), window.end.toString(), listOf(FbItem(calendarId))))
             }
@@ -49,11 +48,11 @@ class GoogleCalendarApi(
         return cal.busy.map { TimeInterval(Instant.parse(it.start), Instant.parse(it.end)) }
     }
 
-    suspend fun insertEvent(calendarId: String, event: CalendarEvent) {
+    suspend fun insertEvent(accessToken: String, calendarId: String, event: CalendarEvent) {
         val attendees = if (event.attendeeEmail != null) listOf(EventAttendee(event.attendeeEmail, event.attendeeName)) else emptyList()
         call {
             httpClient.post("https://www.googleapis.com/calendar/v3/calendars/$calendarId/events?sendUpdates=all") {
-                header(HttpHeaders.Authorization, "Bearer ${tokenSource.accessToken()}")
+                header(HttpHeaders.Authorization, "Bearer $accessToken")
                 contentType(ContentType.Application.Json)
                 setBody(EventInsertRequest(event.title, EventTime(event.interval.start.toString()), EventTime(event.interval.end.toString()), attendees))
             }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarProvider.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarProvider.kt
@@ -1,5 +1,6 @@
 package io.vladar107.data.google
 
+import io.vladar107.application.availability.CalendarException
 import io.vladar107.application.availability.CalendarProvider
 import io.vladar107.application.booking.ConnectedCalendarRepository
 import io.vladar107.domain.availability.BusyInterval
@@ -13,7 +14,9 @@ class GoogleCalendarProvider(
 ) : CalendarProvider {
     override suspend fun busyIntervals(window: TimeInterval): List<BusyInterval> =
         repo.googleCalendars().flatMap { cal ->
-            val token = tokens.accessToken(cal.refreshToken!!)
-            api.freeBusy(token, cal.externalCalendarId!!, window).map { BusyInterval(it, cal.id.toString()) }
+            val rt = cal.refreshToken ?: throw CalendarException("Connected calendar ${cal.id} is missing a refresh token")
+            val calId = cal.externalCalendarId ?: throw CalendarException("Connected calendar ${cal.id} is missing a calendar id")
+            val token = tokens.accessToken(rt)
+            api.freeBusy(token, calId, window).map { BusyInterval(it, cal.id.toString()) }
         }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarProvider.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarProvider.kt
@@ -1,11 +1,19 @@
 package io.vladar107.data.google
 
 import io.vladar107.application.availability.CalendarProvider
+import io.vladar107.application.booking.ConnectedCalendarRepository
 import io.vladar107.domain.availability.BusyInterval
 import io.vladar107.domain.availability.TimeInterval
 
-/** Reads free/busy from the single configured Google calendar. */
-class GoogleCalendarProvider(private val api: GoogleCalendarApi, private val calendarId: String) : CalendarProvider {
+/** Busy = union of free/busy across every connected Google calendar. */
+class GoogleCalendarProvider(
+    private val repo: ConnectedCalendarRepository,
+    private val tokens: GoogleTokenManager,
+    private val api: GoogleCalendarApi,
+) : CalendarProvider {
     override suspend fun busyIntervals(window: TimeInterval): List<BusyInterval> =
-        api.freeBusy(calendarId, window).map { BusyInterval(it, calendarId) }
+        repo.googleCalendars().flatMap { cal ->
+            val token = tokens.accessToken(cal.refreshToken!!)
+            api.freeBusy(token, cal.externalCalendarId!!, window).map { BusyInterval(it, cal.id.toString()) }
+        }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarWriter.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarWriter.kt
@@ -1,5 +1,6 @@
 package io.vladar107.data.google
 
+import io.vladar107.application.availability.CalendarException
 import io.vladar107.application.availability.CalendarWriter
 import io.vladar107.application.availability.NoBookingCalendarException
 import io.vladar107.application.booking.ConnectedCalendarRepository
@@ -13,6 +14,8 @@ class GoogleCalendarWriter(
 ) : CalendarWriter {
     override suspend fun createEvent(calendarId: String, event: CalendarEvent) {
         val target = repo.bookingTarget() ?: throw NoBookingCalendarException()
-        api.insertEvent(tokens.accessToken(target.refreshToken!!), target.externalCalendarId!!, event)
+        val rt = target.refreshToken ?: throw CalendarException("Connected calendar ${target.id} is missing a refresh token")
+        val calId = target.externalCalendarId ?: throw CalendarException("Connected calendar ${target.id} is missing a calendar id")
+        api.insertEvent(tokens.accessToken(rt), calId, event)
     }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarWriter.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleCalendarWriter.kt
@@ -1,9 +1,18 @@
 package io.vladar107.data.google
 
 import io.vladar107.application.availability.CalendarWriter
+import io.vladar107.application.availability.NoBookingCalendarException
+import io.vladar107.application.booking.ConnectedCalendarRepository
 import io.vladar107.domain.availability.CalendarEvent
 
-/** Writes bookings to the single configured Google calendar (ignores the per-call id in this single-calendar slice). */
-class GoogleCalendarWriter(private val api: GoogleCalendarApi, private val calendarId: String) : CalendarWriter {
-    override suspend fun createEvent(calendarId: String, event: CalendarEvent) = api.insertEvent(this.calendarId, event)
+/** Writes bookings to the single is_booking_target calendar (ignores the per-call id). */
+class GoogleCalendarWriter(
+    private val repo: ConnectedCalendarRepository,
+    private val tokens: GoogleTokenManager,
+    private val api: GoogleCalendarApi,
+) : CalendarWriter {
+    override suspend fun createEvent(calendarId: String, event: CalendarEvent) {
+        val target = repo.bookingTarget() ?: throw NoBookingCalendarException()
+        api.insertEvent(tokens.accessToken(target.refreshToken!!), target.externalCalendarId!!, event)
+    }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleOAuthApi.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleOAuthApi.kt
@@ -1,0 +1,92 @@
+package io.vladar107.data.google
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Parameters
+import io.ktor.http.encodeURLParameter
+import io.ktor.http.isSuccess
+import io.vladar107.application.availability.CalendarException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+data class GoogleTokens(val accessToken: String, val refreshToken: String)
+
+class GoogleOAuthApi(
+    private val clientId: String,
+    private val clientSecret: String,
+    private val redirectUri: String,
+    private val httpClient: HttpClient,
+) {
+    @Serializable
+    private data class TokenResponse(
+        @SerialName("access_token") val accessToken: String,
+        @SerialName("refresh_token") val refreshToken: String,
+        @SerialName("expires_in") val expiresIn: Long,
+    )
+
+    @Serializable
+    private data class CalendarPrimaryResponse(val id: String)
+
+    /**
+     * Builds the Google OAuth2 authorization URL with the given [state] nonce.
+     * Scope: https://www.googleapis.com/auth/calendar, offline access, forced consent prompt.
+     */
+    fun authorizationUrl(state: String): String {
+        val scope = "https://www.googleapis.com/auth/calendar".encodeURLParameter()
+        val redirect = redirectUri.encodeURLParameter()
+        val st = state.encodeURLParameter()
+        val cid = clientId.encodeURLParameter()
+        return "https://accounts.google.com/o/oauth2/v2/auth" +
+            "?client_id=$cid" +
+            "&redirect_uri=$redirect" +
+            "&response_type=code" +
+            "&scope=$scope" +
+            "&access_type=offline" +
+            "&prompt=consent" +
+            "&state=$st"
+    }
+
+    /**
+     * Exchanges an authorization [code] for access + refresh tokens.
+     * Throws [CalendarException] on non-2xx.
+     */
+    suspend fun exchangeCode(code: String): GoogleTokens {
+        val response = try {
+            httpClient.submitForm(
+                url = "https://oauth2.googleapis.com/token",
+                formParameters = Parameters.build {
+                    append("grant_type", "authorization_code")
+                    append("code", code)
+                    append("client_id", clientId)
+                    append("client_secret", clientSecret)
+                    append("redirect_uri", redirectUri)
+                },
+            )
+        } catch (e: Exception) {
+            throw CalendarException("Google OAuth token exchange failed", e)
+        }
+        if (!response.status.isSuccess()) throw CalendarException("Google OAuth token exchange failed: ${response.status}")
+        val token = response.body<TokenResponse>()
+        return GoogleTokens(token.accessToken, token.refreshToken)
+    }
+
+    /**
+     * Reads the primary calendar's id, which is the Google account email address.
+     * Throws [CalendarException] on non-2xx.
+     */
+    suspend fun accountEmail(accessToken: String): String {
+        val response = try {
+            httpClient.get("https://www.googleapis.com/calendar/v3/calendars/primary") {
+                header(HttpHeaders.Authorization, "Bearer $accessToken")
+            }
+        } catch (e: Exception) {
+            throw CalendarException("Google Calendar primary read failed", e)
+        }
+        if (!response.status.isSuccess()) throw CalendarException("Google Calendar primary read failed: ${response.status}")
+        return response.body<CalendarPrimaryResponse>().id
+    }
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleTokenManager.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/google/GoogleTokenManager.kt
@@ -1,0 +1,18 @@
+package io.vladar107.data.google
+
+import io.ktor.client.HttpClient
+import java.time.Clock
+import java.util.concurrent.ConcurrentHashMap
+
+/** One access-token cache (a GoogleTokenSource) per refresh token. */
+class GoogleTokenManager(
+    private val clientId: String,
+    private val clientSecret: String,
+    private val httpClient: HttpClient,
+    private val clock: Clock,
+) {
+    private val sources = ConcurrentHashMap<String, GoogleTokenSource>()
+
+    suspend fun accessToken(refreshToken: String): String =
+        sources.computeIfAbsent(refreshToken) { GoogleTokenSource(clientId, clientSecret, it, httpClient, clock) }.accessToken()
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/data/persistence/Tables.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/persistence/Tables.kt
@@ -29,5 +29,9 @@ object EventTypeTable : Table("event_type") {
 
 object ConnectedCalendarTable : Table("connected_calendar") {
     val id = uuid("id"); val name = varchar("name", 256); val provider = varchar("provider", 32); val createdAt = varchar("created_at", 64)
+    val accountEmail = varchar("account_email", 256).nullable()
+    val externalCalendarId = varchar("external_calendar_id", 256).nullable()
+    val refreshToken = varchar("refresh_token", 512).nullable()
+    val isBookingTarget = bool("is_booking_target")
     override val primaryKey = PrimaryKey(id)
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/repositories/ExposedConnectedCalendarRepository.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/repositories/ExposedConnectedCalendarRepository.kt
@@ -4,6 +4,7 @@ import io.vladar107.application.booking.ConnectedCalendarRepository
 import io.vladar107.data.persistence.ConnectedCalendarTable
 import io.vladar107.domain.booking.ConnectedCalendar
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
@@ -57,6 +58,10 @@ class ExposedConnectedCalendarRepository : ConnectedCalendarRepository {
     } }
 
     override suspend fun setBookingTarget(id: java.util.UUID) { transaction {
+        val isGoogleRow = ConnectedCalendarTable.selectAll()
+            .where { (ConnectedCalendarTable.id eq id.toKotlinUuid()) and (ConnectedCalendarTable.provider eq "GOOGLE") }
+            .count() > 0
+        if (!isGoogleRow) return@transaction
         ConnectedCalendarTable.update({ ConnectedCalendarTable.provider eq "GOOGLE" }) { it[isBookingTarget] = false }
         ConnectedCalendarTable.update({ ConnectedCalendarTable.id eq id.toKotlinUuid() }) { it[isBookingTarget] = true }
     } }
@@ -69,6 +74,7 @@ class ExposedConnectedCalendarRepository : ConnectedCalendarRepository {
         if (wasTarget) {
             val next = ConnectedCalendarTable.selectAll()
                 .where { ConnectedCalendarTable.provider eq "GOOGLE" }
+                .orderBy(ConnectedCalendarTable.createdAt, SortOrder.ASC)
                 .firstOrNull()
             if (next != null) {
                 ConnectedCalendarTable.update({ ConnectedCalendarTable.id eq next[ConnectedCalendarTable.id] }) { it[isBookingTarget] = true }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/repositories/ExposedConnectedCalendarRepository.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/repositories/ExposedConnectedCalendarRepository.kt
@@ -4,15 +4,25 @@ import io.vladar107.application.booking.ConnectedCalendarRepository
 import io.vladar107.data.persistence.ConnectedCalendarTable
 import io.vladar107.domain.booking.ConnectedCalendar
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import kotlin.uuid.toJavaUuid
+import kotlin.uuid.toKotlinUuid
 
 class ExposedConnectedCalendarRepository : ConnectedCalendarRepository {
     private fun map(r: ResultRow) = ConnectedCalendar(
         r[ConnectedCalendarTable.id].toJavaUuid(),
         r[ConnectedCalendarTable.name],
-        r[ConnectedCalendarTable.provider]
+        r[ConnectedCalendarTable.provider],
+        r[ConnectedCalendarTable.accountEmail],
+        r[ConnectedCalendarTable.externalCalendarId],
+        r[ConnectedCalendarTable.refreshToken],
+        r[ConnectedCalendarTable.isBookingTarget],
     )
 
     override suspend fun list(): List<ConnectedCalendar> = transaction {
@@ -22,4 +32,47 @@ class ExposedConnectedCalendarRepository : ConnectedCalendarRepository {
     override suspend fun default(): ConnectedCalendar = transaction {
         ConnectedCalendarTable.selectAll().first().let(::map)
     }
+
+    override suspend fun googleCalendars(): List<ConnectedCalendar> = transaction {
+        ConnectedCalendarTable.selectAll().where { ConnectedCalendarTable.provider eq "GOOGLE" }.map(::map)
+    }
+
+    override suspend fun bookingTarget(): ConnectedCalendar? = transaction {
+        ConnectedCalendarTable.selectAll()
+            .where { (ConnectedCalendarTable.provider eq "GOOGLE") and (ConnectedCalendarTable.isBookingTarget eq true) }
+            .firstOrNull()?.let(::map)
+    }
+
+    override suspend fun add(calendar: ConnectedCalendar) { transaction {
+        ConnectedCalendarTable.insert {
+            it[id] = calendar.id.toKotlinUuid()
+            it[name] = calendar.name
+            it[provider] = calendar.provider
+            it[createdAt] = java.time.Instant.now().toString()
+            it[accountEmail] = calendar.accountEmail
+            it[externalCalendarId] = calendar.externalCalendarId
+            it[refreshToken] = calendar.refreshToken
+            it[isBookingTarget] = calendar.isBookingTarget
+        }
+    } }
+
+    override suspend fun setBookingTarget(id: java.util.UUID) { transaction {
+        ConnectedCalendarTable.update({ ConnectedCalendarTable.provider eq "GOOGLE" }) { it[isBookingTarget] = false }
+        ConnectedCalendarTable.update({ ConnectedCalendarTable.id eq id.toKotlinUuid() }) { it[isBookingTarget] = true }
+    } }
+
+    override suspend fun remove(id: java.util.UUID) { transaction {
+        val wasTarget = ConnectedCalendarTable.selectAll()
+            .where { ConnectedCalendarTable.id eq id.toKotlinUuid() }
+            .firstOrNull()?.get(ConnectedCalendarTable.isBookingTarget) ?: false
+        ConnectedCalendarTable.deleteWhere { ConnectedCalendarTable.id eq id.toKotlinUuid() }
+        if (wasTarget) {
+            val next = ConnectedCalendarTable.selectAll()
+                .where { ConnectedCalendarTable.provider eq "GOOGLE" }
+                .firstOrNull()
+            if (next != null) {
+                ConnectedCalendarTable.update({ ConnectedCalendarTable.id eq next[ConnectedCalendarTable.id] }) { it[isBookingTarget] = true }
+            }
+        }
+    } }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/data/repositories/ExposedConnectedCalendarRepository.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/repositories/ExposedConnectedCalendarRepository.kt
@@ -31,7 +31,8 @@ class ExposedConnectedCalendarRepository : ConnectedCalendarRepository {
     }
 
     override suspend fun default(): ConnectedCalendar = transaction {
-        ConnectedCalendarTable.selectAll().first().let(::map)
+        ConnectedCalendarTable.selectAll().orderBy(ConnectedCalendarTable.createdAt, SortOrder.ASC).firstOrNull()?.let(::map)
+            ?: error("No connected calendar configured")
     }
 
     override suspend fun googleCalendars(): List<ConnectedCalendar> = transaction {

--- a/time-matcher/src/main/kotlin/io/vladar107/data/telegram/TelegramApi.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/telegram/TelegramApi.kt
@@ -1,0 +1,165 @@
+package io.vladar107.data.telegram
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+// ---- Public DTOs ----
+
+@Serializable
+data class TgUser(val id: Long)
+
+@Serializable
+data class TgChat(val id: Long)
+
+@Serializable
+data class TgMessage(
+    @SerialName("message_id") val messageId: Long,
+    val from: TgUser? = null,
+    val chat: TgChat,
+    val text: String? = null,
+)
+
+@Serializable
+data class TgCallbackQuery(
+    val id: String,
+    val from: TgUser,
+    val message: TgMessage? = null,
+    val data: String? = null,
+)
+
+@Serializable
+data class TgUpdate(
+    @SerialName("update_id") val updateId: Long,
+    val message: TgMessage? = null,
+    @SerialName("callback_query") val callbackQuery: TgCallbackQuery? = null,
+)
+
+/**
+ * Represents a single inline keyboard button. Exactly one of [callbackData] or [url] should be set.
+ */
+data class TgButton(
+    val text: String,
+    val callbackData: String? = null,
+    val url: String? = null,
+)
+
+// ---- Private wire DTOs ----
+
+@Serializable
+private data class TgUpdatesResponse(
+    val ok: Boolean,
+    val result: List<TgUpdate> = emptyList(),
+)
+
+@Serializable
+private data class InlineButton(
+    val text: String,
+    @SerialName("callback_data") val callbackData: String? = null,
+    val url: String? = null,
+)
+
+@Serializable
+private data class InlineKeyboardMarkup(
+    @SerialName("inline_keyboard") val inlineKeyboard: List<List<InlineButton>>,
+)
+
+@Serializable
+private data class SendMessageRequest(
+    @SerialName("chat_id") val chatId: Long,
+    val text: String,
+    @SerialName("reply_markup") val replyMarkup: InlineKeyboardMarkup? = null,
+)
+
+@Serializable
+private data class AnswerCallbackRequest(
+    @SerialName("callback_query_id") val callbackQueryId: String,
+)
+
+/** JSON configured to omit null fields and defaults — required for correct Telegram wire format. */
+private val telegramJson = Json {
+    encodeDefaults = false
+    explicitNulls = false
+    ignoreUnknownKeys = true
+}
+
+/**
+ * Raw Telegram Bot API client covering the three methods needed by the bot loop.
+ *
+ * @param botToken Bot token issued by @BotFather.
+ * @param httpClient Ktor HTTP client with ContentNegotiation/JSON installed.
+ */
+class TelegramApi(botToken: String, private val httpClient: HttpClient) {
+
+    private val base = "https://api.telegram.org/bot$botToken"
+
+    /**
+     * Fetches pending updates starting from [offset] using long-polling.
+     * Throws on non-2xx so the caller can back off.
+     */
+    suspend fun getUpdates(offset: Long, timeoutSeconds: Int = 25): List<TgUpdate> {
+        val resp = call { httpClient.get("$base/getUpdates?offset=$offset&timeout=$timeoutSeconds") }
+        return resp.body<TgUpdatesResponse>().result
+    }
+
+    /**
+     * Sends a text message to [chatId], optionally with an inline keyboard.
+     * Non-2xx errors are logged and swallowed (bot UX — best-effort delivery).
+     */
+    suspend fun sendMessage(chatId: Long, text: String, buttons: List<List<TgButton>> = emptyList()) {
+        val markup = if (buttons.isEmpty()) null
+        else InlineKeyboardMarkup(buttons.map { row -> row.map { btn -> InlineButton(btn.text, btn.callbackData, btn.url) } })
+        val req = SendMessageRequest(chatId, text, markup)
+        val body = telegramJson.encodeToString(SendMessageRequest.serializer(), req)
+        val resp = try {
+            httpClient.post("$base/sendMessage") {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+        } catch (e: Exception) {
+            return  // swallow network errors for send
+        }
+        if (!resp.status.isSuccess()) {
+            // log and swallow — bot UX
+        }
+    }
+
+    /**
+     * Acknowledges a callback query so Telegram removes the loading spinner.
+     * Non-2xx errors are swallowed (best-effort).
+     */
+    suspend fun answerCallback(callbackId: String) {
+        val req = AnswerCallbackRequest(callbackId)
+        val body = telegramJson.encodeToString(AnswerCallbackRequest.serializer(), req)
+        try {
+            httpClient.post("$base/answerCallbackQuery") {
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+        } catch (e: Exception) {
+            // swallow
+        }
+    }
+
+    private suspend fun call(block: suspend () -> HttpResponse): HttpResponse {
+        val resp = try {
+            block()
+        } catch (e: Exception) {
+            throw TelegramException("Telegram request failed", e)
+        }
+        if (!resp.status.isSuccess()) throw TelegramException("Telegram error: ${resp.status}")
+        return resp
+    }
+}
+
+/** Thrown by [TelegramApi.getUpdates] on network or non-2xx errors. */
+class TelegramException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/time-matcher/src/main/kotlin/io/vladar107/data/telegram/TelegramApi.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/data/telegram/TelegramApi.kt
@@ -100,6 +100,7 @@ private val telegramJson = Json {
  */
 class TelegramApi(botToken: String, private val httpClient: HttpClient) {
 
+    private val logger = org.slf4j.LoggerFactory.getLogger(TelegramApi::class.java)
     private val base = "https://api.telegram.org/bot$botToken"
 
     /**
@@ -129,7 +130,7 @@ class TelegramApi(botToken: String, private val httpClient: HttpClient) {
             return  // swallow network errors for send
         }
         if (!resp.status.isSuccess()) {
-            // log and swallow — bot UX
+            logger.warn("Telegram sendMessage failed: {}", resp.status)
         }
     }
 
@@ -141,10 +142,11 @@ class TelegramApi(botToken: String, private val httpClient: HttpClient) {
         val req = AnswerCallbackRequest(callbackId)
         val body = telegramJson.encodeToString(AnswerCallbackRequest.serializer(), req)
         try {
-            httpClient.post("$base/answerCallbackQuery") {
+            val resp = httpClient.post("$base/answerCallbackQuery") {
                 contentType(ContentType.Application.Json)
                 setBody(body)
             }
+            if (!resp.status.isSuccess()) logger.warn("Telegram answerCallbackQuery failed: {}", resp.status)
         } catch (e: Exception) {
             // swallow
         }

--- a/time-matcher/src/main/kotlin/io/vladar107/domain/booking/ConnectedCalendar.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/domain/booking/ConnectedCalendar.kt
@@ -2,4 +2,12 @@ package io.vladar107.domain.booking
 
 import java.util.UUID
 
-data class ConnectedCalendar(val id: UUID, val name: String, val provider: String)
+data class ConnectedCalendar(
+    val id: UUID,
+    val name: String,
+    val provider: String,
+    val accountEmail: String? = null,
+    val externalCalendarId: String? = null,
+    val refreshToken: String? = null,
+    val isBookingTarget: Boolean = false,
+)

--- a/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureCommands.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureCommands.kt
@@ -5,8 +5,14 @@ import io.vladar107.application.availability.AddBusyBlockCommandHandler
 import io.vladar107.application.booking.BookSlotCommand
 import io.vladar107.application.booking.BookSlotCommandHandler
 import io.vladar107.application.booking.BookingResult
+import io.vladar107.application.booking.ConnectGoogleCalendarCommand
+import io.vladar107.application.booking.ConnectGoogleCalendarCommandHandler
 import io.vladar107.application.booking.CreateEventTypeCommand
 import io.vladar107.application.booking.CreateEventTypeCommandHandler
+import io.vladar107.application.booking.RemoveConnectedCalendarCommand
+import io.vladar107.application.booking.RemoveConnectedCalendarCommandHandler
+import io.vladar107.application.booking.SetBookingTargetCommand
+import io.vladar107.application.booking.SetBookingTargetCommandHandler
 import io.vladar107.application.booking.SetSettingsCommand
 import io.vladar107.application.booking.SetSettingsCommandHandler
 import io.vladar107.application.userCreation.CreatUserCommand
@@ -33,5 +39,14 @@ fun DI.MainBuilder.configureCommands() {
     }
     bind<CommandHandler<BookingResult, BookSlotCommand>>() with singleton {
         BookSlotCommandHandler(instance(), instance(), instance(), instance(), instance(), instance())
+    }
+    bind<CommandHandler<Unit, ConnectGoogleCalendarCommand>>() with provider {
+        ConnectGoogleCalendarCommandHandler(instance())
+    }
+    bind<CommandHandler<Unit, RemoveConnectedCalendarCommand>>() with provider {
+        RemoveConnectedCalendarCommandHandler(instance())
+    }
+    bind<CommandHandler<Unit, SetBookingTargetCommand>>() with provider {
+        SetBookingTargetCommandHandler(instance())
     }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
@@ -16,6 +16,7 @@ import io.vladar107.data.google.GoogleTokenManager
 import io.vladar107.data.persistence.Db
 import io.vladar107.data.repositories.InMemoryCalendarProvider
 import io.vladar107.data.repositories.NoOpCalendarBusyWriter
+import io.vladar107.data.telegram.TelegramApi
 import io.vladar107.web.oauth.ConnectStateStore
 import org.kodein.di.DI
 import org.kodein.di.bind
@@ -28,6 +29,11 @@ fun DI.MainBuilder.configureExternalServices(application: Application) {
         ?: "jdbc:h2:file:./data/timematcher;DB_CLOSE_DELAY=-1"
     Db.init(url)
     bind<Clock>() with singleton { Clock.systemDefaultZone() }
+
+    // Bind TelegramApi unconditionally so both google and in-memory modes can resolve it.
+    // The poll loop (configureTelegramBot) only starts when a real token is configured.
+    val telegramToken = application.environment.config.propertyOrNull("telegram.botToken")?.getString() ?: ""
+    bind<TelegramApi>() with singleton { TelegramApi(telegramToken, HttpClient(CIO) { install(ContentNegotiation) { json() } }) }
 
     val provider = application.environment.config.propertyOrNull("calendar.provider")?.getString() ?: "inmemory"
     if (provider == "google") {

--- a/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
@@ -11,10 +11,12 @@ import io.vladar107.application.availability.CalendarWriter
 import io.vladar107.data.google.GoogleCalendarApi
 import io.vladar107.data.google.GoogleCalendarProvider
 import io.vladar107.data.google.GoogleCalendarWriter
+import io.vladar107.data.google.GoogleOAuthApi
 import io.vladar107.data.google.GoogleTokenManager
 import io.vladar107.data.persistence.Db
 import io.vladar107.data.repositories.InMemoryCalendarProvider
 import io.vladar107.data.repositories.NoOpCalendarBusyWriter
+import io.vladar107.web.oauth.ConnectStateStore
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -33,8 +35,11 @@ fun DI.MainBuilder.configureExternalServices(application: Application) {
         fun req(k: String) = cfg.propertyOrNull(k)?.getString()?.takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("Missing config: $k")
         val httpClient = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        val redirectBase = cfg.propertyOrNull("oauth.redirectBaseUrl")?.getString() ?: "http://localhost:8080"
         bind<GoogleTokenManager>() with singleton { GoogleTokenManager(req("google.clientId"), req("google.clientSecret"), httpClient, instance()) }
         bind<GoogleCalendarApi>() with singleton { GoogleCalendarApi(httpClient) }
+        bind<GoogleOAuthApi>() with singleton { GoogleOAuthApi(req("google.clientId"), req("google.clientSecret"), "$redirectBase/oauth/google/callback", httpClient) }
+        bind<ConnectStateStore>() with singleton { ConnectStateStore(instance()) }
         bind<CalendarProvider>() with singleton { GoogleCalendarProvider(instance(), instance(), instance()) }
         bind<CalendarWriter>() with singleton { GoogleCalendarWriter(instance(), instance(), instance()) }
         bind<CalendarBusyWriter>() with singleton { NoOpCalendarBusyWriter() }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
@@ -11,7 +11,7 @@ import io.vladar107.application.availability.CalendarWriter
 import io.vladar107.data.google.GoogleCalendarApi
 import io.vladar107.data.google.GoogleCalendarProvider
 import io.vladar107.data.google.GoogleCalendarWriter
-import io.vladar107.data.google.GoogleTokenSource
+import io.vladar107.data.google.GoogleTokenManager
 import io.vladar107.data.persistence.Db
 import io.vladar107.data.repositories.InMemoryCalendarProvider
 import io.vladar107.data.repositories.NoOpCalendarBusyWriter
@@ -32,15 +32,11 @@ fun DI.MainBuilder.configureExternalServices(application: Application) {
         val cfg = application.environment.config
         fun req(k: String) = cfg.propertyOrNull(k)?.getString()?.takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("Missing config: $k")
-        val httpClient = HttpClient(CIO) {
-            install(ContentNegotiation) { json() }
-        }
-        val tokenSource = GoogleTokenSource(
-            req("google.clientId"), req("google.clientSecret"), req("google.refreshToken"), httpClient, java.time.Clock.systemUTC())
-        val api = GoogleCalendarApi(tokenSource, httpClient)
-        val calendarId = cfg.propertyOrNull("google.calendarId")?.getString()?.takeIf { it.isNotBlank() } ?: "primary"
-        bind<CalendarProvider>() with singleton { GoogleCalendarProvider(api, calendarId) }
-        bind<CalendarWriter>() with singleton { GoogleCalendarWriter(api, calendarId) }
+        val httpClient = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        bind<GoogleTokenManager>() with singleton { GoogleTokenManager(req("google.clientId"), req("google.clientSecret"), httpClient, instance()) }
+        bind<GoogleCalendarApi>() with singleton { GoogleCalendarApi(httpClient) }
+        bind<CalendarProvider>() with singleton { GoogleCalendarProvider(instance(), instance(), instance()) }
+        bind<CalendarWriter>() with singleton { GoogleCalendarWriter(instance(), instance(), instance()) }
         bind<CalendarBusyWriter>() with singleton { NoOpCalendarBusyWriter() }
     } else {
         bind<InMemoryCalendarProvider>() with singleton { InMemoryCalendarProvider() }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureExternalServices.kt
@@ -34,6 +34,7 @@ fun DI.MainBuilder.configureExternalServices(application: Application) {
     // The poll loop (configureTelegramBot) only starts when a real token is configured.
     val telegramToken = application.environment.config.propertyOrNull("telegram.botToken")?.getString() ?: ""
     bind<TelegramApi>() with singleton { TelegramApi(telegramToken, HttpClient(CIO) { install(ContentNegotiation) { json() } }) }
+    bind<ConnectStateStore>() with singleton { ConnectStateStore(instance()) }
 
     val provider = application.environment.config.propertyOrNull("calendar.provider")?.getString() ?: "inmemory"
     if (provider == "google") {
@@ -45,7 +46,6 @@ fun DI.MainBuilder.configureExternalServices(application: Application) {
         bind<GoogleTokenManager>() with singleton { GoogleTokenManager(req("google.clientId"), req("google.clientSecret"), httpClient, instance()) }
         bind<GoogleCalendarApi>() with singleton { GoogleCalendarApi(httpClient) }
         bind<GoogleOAuthApi>() with singleton { GoogleOAuthApi(req("google.clientId"), req("google.clientSecret"), "$redirectBase/oauth/google/callback", httpClient) }
-        bind<ConnectStateStore>() with singleton { ConnectStateStore(instance()) }
         bind<CalendarProvider>() with singleton { GoogleCalendarProvider(instance(), instance(), instance()) }
         bind<CalendarWriter>() with singleton { GoogleCalendarWriter(instance(), instance(), instance()) }
         bind<CalendarBusyWriter>() with singleton { NoOpCalendarBusyWriter() }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureQueries.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/di/ConfigureQueries.kt
@@ -7,8 +7,11 @@ import io.vladar107.application.booking.FindEventTypeSlotsQuery
 import io.vladar107.application.booking.FindEventTypeSlotsQueryHandler
 import io.vladar107.application.booking.GetEventTypeBySlugQuery
 import io.vladar107.application.booking.GetEventTypeBySlugQueryHandler
+import io.vladar107.application.booking.ListConnectedCalendarsQuery
+import io.vladar107.application.booking.ListConnectedCalendarsQueryHandler
 import io.vladar107.application.booking.ListEventTypesQuery
 import io.vladar107.application.booking.ListEventTypesQueryHandler
+import io.vladar107.domain.booking.ConnectedCalendar
 import io.vladar107.domain.booking.EventType
 import io.vladar107.infrastructure.QueryHandler
 import org.kodein.di.DI
@@ -28,5 +31,8 @@ fun DI.MainBuilder.configureQueries() {
     }
     bind<QueryHandler<AvailableSlots?, FindEventTypeSlotsQuery>>() with provider {
         FindEventTypeSlotsQueryHandler(instance(), instance(), instance(), instance())
+    }
+    bind<QueryHandler<List<ConnectedCalendar>, ListConnectedCalendarsQuery>>() with provider {
+        ListConnectedCalendarsQueryHandler(instance())
     }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/oauth/GoogleOAuthController.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/oauth/GoogleOAuthController.kt
@@ -63,6 +63,9 @@ fun Application.configureGoogleOAuth() {
                 ?: return@get call.respond(HttpStatusCode.BadRequest, "missing state")
             val di = closestDI { this@configureGoogleOAuth }
             val oauthApi: GoogleOAuthApi by di.instance()
+            // `state` is forwarded to Google unvalidated by design: the redirect host is always Google,
+            // and the real gate is the callback, which only accepts nonces this process minted
+            // (ConnectStateStore.consume → 400 on unknown/expired). Do not add validation here.
             call.respondRedirect(oauthApi.authorizationUrl(state))
         }
 

--- a/time-matcher/src/main/kotlin/io/vladar107/web/oauth/GoogleOAuthController.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/oauth/GoogleOAuthController.kt
@@ -13,6 +13,7 @@ import io.vladar107.application.booking.ConnectGoogleCalendarCommand
 import io.vladar107.data.google.GoogleOAuthApi
 import io.vladar107.data.telegram.TelegramApi
 import io.vladar107.infrastructure.CommandProvider
+import org.kodein.di.direct
 import org.kodein.di.instance
 import org.kodein.di.ktor.closestDI
 import java.time.Clock
@@ -87,9 +88,11 @@ fun Application.configureGoogleOAuth() {
             val email = oauthApi.accountEmail(tokens.accessToken)
             commandProvider.run(ConnectGoogleCalendarCommand(email, "primary", tokens.refreshToken))
 
-            // TelegramApi binding is added in Task 6 — resolve it lazily here
-            val telegramApi: TelegramApi by di.instance()
-            runCatching { telegramApi.sendMessage(chatId, "✅ Connected $email") }
+            // TelegramApi binding is added in Task 6 — resolve and send best-effort
+            runCatching {
+                val telegramApi = di.direct.instance<TelegramApi>()
+                telegramApi.sendMessage(chatId, "✅ Connected $email")
+            }.onFailure { call.application.environment.log.warn("Failed to notify Telegram after connect", it) }
 
             call.respondText("✅ Connected $email — you can return to Telegram.", ContentType.Text.Plain)
         }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/oauth/GoogleOAuthController.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/oauth/GoogleOAuthController.kt
@@ -1,0 +1,97 @@
+package io.vladar107.web.oauth
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.vladar107.application.booking.ConnectGoogleCalendarCommand
+import io.vladar107.data.google.GoogleOAuthApi
+import io.vladar107.data.telegram.TelegramApi
+import io.vladar107.infrastructure.CommandProvider
+import org.kodein.di.instance
+import org.kodein.di.ktor.closestDI
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Stores per-connection state nonces with a TTL.
+ * Thread-safe; single-use consumption.
+ */
+class ConnectStateStore(private val clock: Clock, private val ttl: Duration = Duration.ofMinutes(10)) {
+    private data class Entry(val chatId: Long, val expiresAt: Instant)
+    private val map = ConcurrentHashMap<String, Entry>()
+
+    /** Creates a nonce mapped to [chatId] and returns it. */
+    fun create(chatId: Long): String {
+        val n = UUID.randomUUID().toString()
+        map[n] = Entry(chatId, clock.instant().plus(ttl))
+        return n
+    }
+
+    /**
+     * Consumes [state]: removes it and returns its chatId if valid and not expired;
+     * returns null otherwise (unknown, already used, or expired).
+     */
+    fun consume(state: String): Long? {
+        val e = map.remove(state) ?: return null
+        return if (clock.instant().isBefore(e.expiresAt)) e.chatId else null
+    }
+}
+
+/**
+ * Registers the Google OAuth start and callback routes.
+ *
+ * IMPORTANT: All DI resolutions are done INSIDE route handlers (per-request) so that
+ * `Application.module()` can boot in in-memory mode without the google-only bindings
+ * (GoogleOAuthApi, ConnectStateStore, TelegramApi) present. They are only resolved
+ * when an actual request hits /oauth/google/start or /callback, which in-memory test suites never do.
+ */
+fun Application.configureGoogleOAuth() {
+    val commandProvider = CommandProvider(this@configureGoogleOAuth)
+    routing {
+        get("/oauth/google/start") {
+            val state = call.request.queryParameters["state"]
+                ?: return@get call.respond(HttpStatusCode.BadRequest, "missing state")
+            val di = closestDI { this@configureGoogleOAuth }
+            val oauthApi: GoogleOAuthApi by di.instance()
+            call.respondRedirect(oauthApi.authorizationUrl(state))
+        }
+
+        get("/oauth/google/callback") {
+            val code = call.request.queryParameters["code"]
+            val state = call.request.queryParameters["state"]
+
+            // Resolve ConnectStateStore inside the handler — lazy, google-mode only
+            val di = closestDI { this@configureGoogleOAuth }
+            val stateStore: ConnectStateStore by di.instance()
+            val chatId = state?.let { stateStore.consume(it) }
+
+            if (code == null || chatId == null) {
+                return@get call.respondText(
+                    "Link expired — run /connect again in Telegram.",
+                    status = HttpStatusCode.BadRequest,
+                )
+            }
+
+            // Resolve google-only services only on the happy path
+            val oauthApi: GoogleOAuthApi by di.instance()
+            val tokens = oauthApi.exchangeCode(code)
+            val email = oauthApi.accountEmail(tokens.accessToken)
+            commandProvider.run(ConnectGoogleCalendarCommand(email, "primary", tokens.refreshToken))
+
+            // TelegramApi binding is added in Task 6 — resolve it lazily here
+            val telegramApi: TelegramApi by di.instance()
+            runCatching { telegramApi.sendMessage(chatId, "✅ Connected $email") }
+
+            call.respondText("✅ Connected $email — you can return to Telegram.", ContentType.Text.Plain)
+        }
+    }
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/web/plugins/StatusPages.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/plugins/StatusPages.kt
@@ -6,11 +6,15 @@ import io.ktor.server.application.install
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import io.vladar107.application.availability.CalendarException
+import io.vladar107.application.availability.NoBookingCalendarException
 
 fun Application.configureStatusPages() {
     install(StatusPages) {
         exception<CalendarException> { call, _ ->
             call.respond(HttpStatusCode.BadGateway, "Calendar backend unavailable")
+        }
+        exception<NoBookingCalendarException> { call, _ ->
+            call.respond(HttpStatusCode.ServiceUnavailable, "No booking calendar connected")
         }
     }
 }

--- a/time-matcher/src/main/kotlin/io/vladar107/web/telegram/TelegramBot.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/telegram/TelegramBot.kt
@@ -1,0 +1,132 @@
+package io.vladar107.web.telegram
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.vladar107.application.booking.ListConnectedCalendarsQuery
+import io.vladar107.application.booking.RemoveConnectedCalendarCommand
+import io.vladar107.application.booking.SetBookingTargetCommand
+import io.vladar107.data.telegram.TelegramApi
+import io.vladar107.data.telegram.TgButton
+import io.vladar107.data.telegram.TgCallbackQuery
+import io.vladar107.data.telegram.TgMessage
+import io.vladar107.data.telegram.TgUpdate
+import io.vladar107.infrastructure.CommandProvider
+import io.vladar107.infrastructure.QueryProvider
+import io.vladar107.web.oauth.ConnectStateStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.kodein.di.instance
+import org.kodein.di.ktor.closestDI
+import java.util.UUID
+
+/**
+ * Host-only Telegram bot: auth-gates all updates to [hostUserId], then dispatches
+ * text commands and inline-keyboard callbacks to the appropriate use-case handlers.
+ */
+class TelegramBot(
+    private val api: TelegramApi,
+    private val hostUserId: Long,
+    private val stateStore: ConnectStateStore,
+    private val commandProvider: CommandProvider,
+    private val queryProvider: QueryProvider,
+    private val oauthBaseUrl: String,
+) {
+    /** Entry point called by the poll loop and by tests. */
+    suspend fun handle(update: TgUpdate) {
+        val senderId = update.message?.from?.id ?: update.callbackQuery?.from?.id ?: return
+        if (senderId != hostUserId) return
+        update.message?.let { onMessage(it) }
+        update.callbackQuery?.let { onCallback(it) }
+    }
+
+    private suspend fun onMessage(m: TgMessage) {
+        val chatId = m.chat.id
+        when (m.text?.trim()?.substringBefore(' ')) {
+            "/start", "/help" -> api.sendMessage(
+                chatId,
+                "Commands:\n/connect — connect a Google Calendar\n/calendars — list & manage connected calendars",
+            )
+            "/connect" -> {
+                val nonce = stateStore.create(chatId)
+                api.sendMessage(
+                    chatId,
+                    "Tap to connect your Google Calendar:",
+                    listOf(listOf(TgButton("🔗 Connect Google Calendar", url = "$oauthBaseUrl/oauth/google/start?state=$nonce"))),
+                )
+            }
+            "/calendars" -> {
+                val cals = queryProvider.query(ListConnectedCalendarsQuery())
+                if (cals.isEmpty()) {
+                    api.sendMessage(chatId, "No calendars connected yet. Use /connect.")
+                    return
+                }
+                val text = buildString {
+                    append("Connected calendars:\n")
+                    cals.forEach { append(if (it.isBookingTarget) "★ " else "• ").append(it.accountEmail).append('\n') }
+                    append("\n★ = bookings are written here.")
+                }
+                val buttons = cals.map { c ->
+                    listOf(
+                        TgButton(if (c.isBookingTarget) "★ booking" else "Set ★", callbackData = "target:${c.id}"),
+                        TgButton("Remove 🗑", callbackData = "remove:${c.id}"),
+                    )
+                }
+                api.sendMessage(chatId, text, buttons)
+            }
+            else -> api.sendMessage(chatId, "Unknown command. Try /help.")
+        }
+    }
+
+    private suspend fun onCallback(cb: TgCallbackQuery) {
+        val data = cb.data ?: return
+        val chatId = cb.message?.chat?.id ?: cb.from.id
+        when {
+            data.startsWith("target:") -> {
+                commandProvider.run(SetBookingTargetCommand(UUID.fromString(data.removePrefix("target:"))))
+                api.answerCallback(cb.id)
+                api.sendMessage(chatId, "★ Booking target updated.")
+            }
+            data.startsWith("remove:") -> {
+                commandProvider.run(RemoveConnectedCalendarCommand(UUID.fromString(data.removePrefix("remove:"))))
+                api.answerCallback(cb.id)
+                api.sendMessage(chatId, "Calendar removed.")
+            }
+            else -> api.answerCallback(cb.id)
+        }
+    }
+}
+
+/**
+ * Launches the Telegram getUpdates long-poll loop.
+ * Returns early (no-op) when [telegram.botToken] is blank — this keeps tests from polling.
+ * Note: intentionally NOT called from [Application.module] yet (Task 7 wires it).
+ */
+fun Application.configureTelegramBot() {
+    val token = environment.config.propertyOrNull("telegram.botToken")?.getString()?.takeIf { it.isNotBlank() } ?: return
+    val hostUserId = environment.config.property("telegram.hostUserId").getString().toLong()
+    val redirectBase = environment.config.propertyOrNull("oauth.redirectBaseUrl")?.getString() ?: "http://localhost:8080"
+    val di = closestDI { this@configureTelegramBot }
+    val api: TelegramApi by di.instance()
+    val stateStore: ConnectStateStore by di.instance()
+    val bot = TelegramBot(api, hostUserId, stateStore, CommandProvider(this), QueryProvider(this), redirectBase)
+    launch(Dispatchers.IO) {
+        var offset = 0L
+        while (isActive) {
+            try {
+                val updates = api.getUpdates(offset)
+                for (u in updates) {
+                    offset = u.updateId + 1
+                    bot.handle(u)
+                }
+            } catch (e: Exception) {
+                environment.log.error("Telegram poll loop error", e)
+                delay(3000)
+            }
+        }
+    }
+}

--- a/time-matcher/src/main/kotlin/io/vladar107/web/telegram/TelegramBot.kt
+++ b/time-matcher/src/main/kotlin/io/vladar107/web/telegram/TelegramBot.kt
@@ -78,6 +78,7 @@ class TelegramBot(
                 }
                 api.sendMessage(chatId, text, buttons)
             }
+            null -> { }
             else -> api.sendMessage(chatId, "Unknown command. Try /help.")
         }
     }

--- a/time-matcher/src/main/resources/application.yaml
+++ b/time-matcher/src/main/resources/application.yaml
@@ -14,5 +14,10 @@ calendar:
 google:
     clientId: "$GOOGLE_CLIENT_ID:"
     clientSecret: "$GOOGLE_CLIENT_SECRET:"
-    refreshToken: "$GOOGLE_REFRESH_TOKEN:"
-    calendarId: "$GOOGLE_CALENDAR_ID:primary"
+
+oauth:
+    redirectBaseUrl: "$OAUTH_REDIRECT_BASE_URL:http://localhost:8080"
+
+telegram:
+    botToken: "$TELEGRAM_BOT_TOKEN:"
+    hostUserId: "$TELEGRAM_HOST_USER_ID:0"

--- a/time-matcher/src/main/resources/db/migration/V2__connected_calendar_oauth.sql
+++ b/time-matcher/src/main/resources/db/migration/V2__connected_calendar_oauth.sql
@@ -1,0 +1,4 @@
+ALTER TABLE connected_calendar ADD COLUMN account_email VARCHAR(256);
+ALTER TABLE connected_calendar ADD COLUMN external_calendar_id VARCHAR(256);
+ALTER TABLE connected_calendar ADD COLUMN refresh_token VARCHAR(512);
+ALTER TABLE connected_calendar ADD COLUMN is_booking_target BOOLEAN NOT NULL DEFAULT FALSE;

--- a/time-matcher/src/test/kotlin/io/vladar107/application/booking/BookSlotCommandTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/application/booking/BookSlotCommandTest.kt
@@ -47,7 +47,12 @@ class BookSlotCommandTest {
             provider, writer,
             object : ConnectedCalendarRepository {
                 override suspend fun list() = listOf(ConnectedCalendar(UUID.randomUUID(), "Default", "IN_MEMORY"))
-                override suspend fun default() = ConnectedCalendar(UUID.randomUUID(), "Default", "IN_MEMORY") },
+                override suspend fun default() = ConnectedCalendar(UUID.randomUUID(), "Default", "IN_MEMORY")
+                override suspend fun googleCalendars() = emptyList<ConnectedCalendar>()
+                override suspend fun bookingTarget() = null
+                override suspend fun add(calendar: ConnectedCalendar) {}
+                override suspend fun remove(id: UUID) {}
+                override suspend fun setBookingTarget(id: UUID) {} },
             Clock.fixed(t("2020-01-01T00:00:00Z"), zone))
     }
 
@@ -91,6 +96,11 @@ class BookSlotCommandTest {
             object : ConnectedCalendarRepository {
                 override suspend fun list() = listOf(ConnectedCalendar(UUID.randomUUID(), "Default", "IN_MEMORY"))
                 override suspend fun default() = ConnectedCalendar(UUID.randomUUID(), "Default", "IN_MEMORY")
+                override suspend fun googleCalendars() = emptyList<ConnectedCalendar>()
+                override suspend fun bookingTarget() = null
+                override suspend fun add(calendar: ConnectedCalendar) {}
+                override suspend fun remove(id: UUID) {}
+                override suspend fun setBookingTarget(id: UUID) {}
             },
             Clock.fixed(t("2020-01-01T00:00:00Z"), zone))
         // Slot [09:00,10:00] should be blocked because the pre-buffer of the 10:00 busy event reaches 09:30

--- a/time-matcher/src/test/kotlin/io/vladar107/application/booking/ConnectedCalendarCommandsTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/application/booking/ConnectedCalendarCommandsTest.kt
@@ -1,0 +1,43 @@
+package io.vladar107.application.booking
+
+import io.vladar107.domain.booking.ConnectedCalendar
+import kotlinx.coroutines.runBlocking
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConnectedCalendarCommandsTest {
+    // Minimal in-memory fake of the port.
+    private class FakeRepo : ConnectedCalendarRepository {
+        val rows = mutableListOf<ConnectedCalendar>()
+        override suspend fun list() = rows.toList()
+        override suspend fun default() = rows.first()
+        override suspend fun googleCalendars() = rows.filter { it.provider == "GOOGLE" }
+        override suspend fun bookingTarget() = rows.firstOrNull { it.provider == "GOOGLE" && it.isBookingTarget }
+        override suspend fun add(calendar: ConnectedCalendar) { rows += calendar }
+        override suspend fun remove(id: UUID) { rows.removeIf { it.id == id } }
+        override suspend fun setBookingTarget(id: UUID) { rows.replaceAll { it.copy(isBookingTarget = it.id == id) } }
+    }
+
+    @Test fun firstConnectedGoogleCalendarBecomesBookingTarget() = runBlocking {
+        val repo = FakeRepo(); val h = ConnectGoogleCalendarCommandHandler(repo)
+        h.handle(ConnectGoogleCalendarCommand("a@x.com", "primary", "rt1"))
+        assertEquals("a@x.com", repo.bookingTarget()?.accountEmail)
+        h.handle(ConnectGoogleCalendarCommand("b@x.com", "primary", "rt2"))
+        assertEquals("a@x.com", repo.bookingTarget()?.accountEmail) // second does NOT steal the target
+        assertEquals(2, repo.googleCalendars().size)
+    }
+
+    @Test fun setTargetAndRemoveDelegateToRepo() = runBlocking {
+        val repo = FakeRepo()
+        ConnectGoogleCalendarCommandHandler(repo).handle(ConnectGoogleCalendarCommand("a@x.com", "primary", "rt1"))
+        ConnectGoogleCalendarCommandHandler(repo).handle(ConnectGoogleCalendarCommand("b@x.com", "primary", "rt2"))
+        val b = repo.googleCalendars().first { it.accountEmail == "b@x.com" }
+        SetBookingTargetCommandHandler(repo).handle(SetBookingTargetCommand(b.id))
+        assertEquals("b@x.com", repo.bookingTarget()?.accountEmail)
+        RemoveConnectedCalendarCommandHandler(repo).handle(RemoveConnectedCalendarCommand(b.id))
+        assertTrue(repo.googleCalendars().none { it.accountEmail == "b@x.com" })
+        assertEquals(listOf("a@x.com"), ListConnectedCalendarsQueryHandler(repo).handle(ListConnectedCalendarsQuery()).map { it.accountEmail })
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleCalendarApiTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleCalendarApiTest.kt
@@ -12,9 +12,7 @@ import io.vladar107.application.availability.CalendarException
 import io.vladar107.domain.availability.CalendarEvent
 import io.vladar107.domain.availability.TimeInterval
 import kotlinx.coroutines.runBlocking
-import java.time.Clock
 import java.time.Instant
-import java.time.ZoneId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -23,44 +21,38 @@ import kotlin.test.assertTrue
 class GoogleCalendarApiTest {
     private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
     private fun t(s: String) = Instant.parse(s)
-    private val clock = Clock.fixed(t("2030-01-01T00:00:00Z"), ZoneId.of("UTC"))
-
-    // A token client that always returns a valid access token (for GoogleTokenSource).
-    private fun tokenSource() = GoogleTokenSource("cid", "sec", "rt",
-        HttpClient(MockEngine { respond("""{"access_token":"AT","expires_in":3600}""", HttpStatusCode.OK, jsonHeaders) }) { install(ContentNegotiation) { json() } },
-        clock)
 
     @Test fun freeBusyMapsBusyIntervals() = runBlocking {
         val body = """{"calendars":{"primary":{"busy":[{"start":"2030-01-07T10:00:00Z","end":"2030-01-07T11:00:00Z"}]}}}"""
-        val api = GoogleCalendarApi(tokenSource(),
+        val api = GoogleCalendarApi(
             HttpClient(MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }) { install(ContentNegotiation) { json() } })
-        val busy = api.freeBusy("primary", TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z")))
+        val busy = api.freeBusy("AT", "primary", TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z")))
         assertEquals(listOf(TimeInterval(t("2030-01-07T10:00:00Z"), t("2030-01-07T11:00:00Z"))), busy)
     }
 
     @Test fun insertEventSendsAttendeeAndSucceeds() = runBlocking {
         var captured = ""
-        val api = GoogleCalendarApi(tokenSource(),
+        val api = GoogleCalendarApi(
             HttpClient(MockEngine { req ->
                 assertTrue(req.url.toString().contains("sendUpdates=all"))
                 captured = (req.body as io.ktor.http.content.TextContent).text
                 respond("""{"id":"evt1"}""", HttpStatusCode.OK, jsonHeaders)
             }) { install(ContentNegotiation) { json() } })
-        api.insertEvent("primary", CalendarEvent(TimeInterval(t("2030-01-07T09:00:00Z"), t("2030-01-07T10:00:00Z")), "Intro with Sam", "Sam", "sam@example.com"))
+        api.insertEvent("AT", "primary", CalendarEvent(TimeInterval(t("2030-01-07T09:00:00Z"), t("2030-01-07T10:00:00Z")), "Intro with Sam", "Sam", "sam@example.com"))
         assertTrue(captured.contains("sam@example.com"))
         assertTrue(captured.contains("Intro with Sam"))
     }
 
     @Test fun nonSuccessThrowsCalendarException() = runBlocking<Unit> {
-        val api = GoogleCalendarApi(tokenSource(),
+        val api = GoogleCalendarApi(
             HttpClient(MockEngine { respond("""{"error":{"code":500}}""", HttpStatusCode.InternalServerError, jsonHeaders) }) { install(ContentNegotiation) { json() } })
-        assertFailsWith<CalendarException> { api.freeBusy("primary", TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z"))) }
+        assertFailsWith<CalendarException> { api.freeBusy("AT", "primary", TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z"))) }
     }
 
     @Test fun freeBusyPerCalendarErrorThrowsCalendarException() = runBlocking<Unit> {
         val body = """{"calendars":{"primary":{"errors":[{"domain":"calendar","reason":"notFound"}]}}}"""
-        val api = GoogleCalendarApi(tokenSource(),
+        val api = GoogleCalendarApi(
             HttpClient(MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }) { install(ContentNegotiation) { json() } })
-        assertFailsWith<CalendarException> { api.freeBusy("primary", TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z"))) }
+        assertFailsWith<CalendarException> { api.freeBusy("AT", "primary", TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z"))) }
     }
 }

--- a/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleCalendarMultiTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleCalendarMultiTest.kt
@@ -1,0 +1,77 @@
+package io.vladar107.data.google
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.vladar107.application.availability.NoBookingCalendarException
+import io.vladar107.application.booking.ConnectedCalendarRepository
+import io.vladar107.domain.availability.CalendarEvent
+import io.vladar107.domain.availability.TimeInterval
+import io.vladar107.domain.booking.ConnectedCalendar
+import kotlinx.coroutines.runBlocking
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class GoogleCalendarMultiTest {
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+    private fun t(s: String) = Instant.parse(s)
+    private val clock = Clock.fixed(t("2030-01-01T00:00:00Z"), ZoneId.of("UTC"))
+    private fun client(handler: io.ktor.client.engine.mock.MockRequestHandler) =
+        HttpClient(MockEngine(handler)) { install(ContentNegotiation) { json() } }
+    private fun tokens() = GoogleTokenManager("cid", "sec",
+        client { respond("""{"access_token":"AT","expires_in":3600}""", HttpStatusCode.OK, jsonHeaders) }, clock)
+
+    private class FakeRepo(private val rows: List<ConnectedCalendar>) : ConnectedCalendarRepository {
+        override suspend fun list() = rows
+        override suspend fun default() = rows.first()
+        override suspend fun googleCalendars() = rows.filter { it.provider == "GOOGLE" }
+        override suspend fun bookingTarget() = rows.firstOrNull { it.provider == "GOOGLE" && it.isBookingTarget }
+        override suspend fun add(calendar: ConnectedCalendar) {}
+        override suspend fun remove(id: UUID) {}
+        override suspend fun setBookingTarget(id: UUID) {}
+    }
+    private fun g(email: String, target: Boolean = false) =
+        ConnectedCalendar(UUID.randomUUID(), email, "GOOGLE", email, "primary", "rt-$email", target)
+
+    @Test fun busyIsUnionedAcrossAllConnectedCalendars() = runBlocking {
+        val repo = FakeRepo(listOf(g("a@x.com"), g("b@x.com")))
+        // freeBusy always reports the queried calendar (id "primary") busy 10-11 for each account.
+        val api = GoogleCalendarApi(client { respond(
+            """{"calendars":{"primary":{"busy":[{"start":"2030-01-07T10:00:00Z","end":"2030-01-07T11:00:00Z"}]}}}""",
+            HttpStatusCode.OK, jsonHeaders) })
+        val provider = GoogleCalendarProvider(repo, tokens(), api)
+        val busy = provider.busyIntervals(TimeInterval(t("2030-01-07T00:00:00Z"), t("2030-01-07T23:59:59Z")))
+        assertEquals(2, busy.size) // one per connected calendar
+        assertTrue(busy.all { it.interval == TimeInterval(t("2030-01-07T10:00:00Z"), t("2030-01-07T11:00:00Z")) })
+    }
+
+    @Test fun bookingWritesToTheTargetCalendar() = runBlocking {
+        val repo = FakeRepo(listOf(g("a@x.com"), g("b@x.com", target = true)))
+        var captured = ""
+        val api = GoogleCalendarApi(client { req -> captured = (req.body as io.ktor.http.content.TextContent).text
+            respond("""{"id":"evt1"}""", HttpStatusCode.OK, jsonHeaders) })
+        GoogleCalendarWriter(repo, tokens(), api).createEvent("ignored",
+            CalendarEvent(TimeInterval(t("2030-01-07T09:00:00Z"), t("2030-01-07T10:00:00Z")), "Intro with Sam", "Sam", "sam@example.com"))
+        assertTrue(captured.contains("Intro with Sam"))
+    }
+
+    @Test fun bookingWithNoTargetThrows() = runBlocking<Unit> {
+        val repo = FakeRepo(listOf(g("a@x.com"))) // present but not a target
+        val api = GoogleCalendarApi(client { respond("{}", HttpStatusCode.OK, jsonHeaders) })
+        assertFailsWith<NoBookingCalendarException> {
+            GoogleCalendarWriter(repo, tokens(), api).createEvent("ignored",
+                CalendarEvent(TimeInterval(t("2030-01-07T09:00:00Z"), t("2030-01-07T10:00:00Z")), "x", "n", "e@e.com"))
+        }
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleCalendarMultiTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleCalendarMultiTest.kt
@@ -57,13 +57,20 @@ class GoogleCalendarMultiTest {
     }
 
     @Test fun bookingWritesToTheTargetCalendar() = runBlocking {
-        val repo = FakeRepo(listOf(g("a@x.com"), g("b@x.com", target = true)))
-        var captured = ""
-        val api = GoogleCalendarApi(client { req -> captured = (req.body as io.ktor.http.content.TextContent).text
-            respond("""{"id":"evt1"}""", HttpStatusCode.OK, jsonHeaders) })
+        val nonTarget = ConnectedCalendar(UUID.randomUUID(), "a@x.com", "GOOGLE", "a@x.com", "cal-a", "rt-a", false)
+        val target    = ConnectedCalendar(UUID.randomUUID(), "b@x.com", "GOOGLE", "b@x.com", "cal-b", "rt-b", true)
+        val repo = FakeRepo(listOf(nonTarget, target))
+        var capturedUrl = ""
+        var capturedBody = ""
+        val api = GoogleCalendarApi(client { req ->
+            capturedUrl = req.url.toString()
+            capturedBody = (req.body as io.ktor.http.content.TextContent).text
+            respond("""{"id":"evt1"}""", HttpStatusCode.OK, jsonHeaders)
+        })
         GoogleCalendarWriter(repo, tokens(), api).createEvent("ignored",
             CalendarEvent(TimeInterval(t("2030-01-07T09:00:00Z"), t("2030-01-07T10:00:00Z")), "Intro with Sam", "Sam", "sam@example.com"))
-        assertTrue(captured.contains("Intro with Sam"))
+        assertTrue(capturedUrl.contains("cal-b"), "expected URL to contain cal-b but was: $capturedUrl")
+        assertTrue(capturedBody.contains("Intro with Sam"))
     }
 
     @Test fun bookingWithNoTargetThrows() = runBlocking<Unit> {

--- a/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleOAuthApiTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/google/GoogleOAuthApiTest.kt
@@ -1,0 +1,39 @@
+package io.vladar107.data.google
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GoogleOAuthApiTest {
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+    private fun api(handler: io.ktor.client.engine.mock.MockRequestHandler) = GoogleOAuthApi(
+        "cid", "sec", "http://localhost:8080/oauth/google/callback",
+        HttpClient(MockEngine(handler)) { install(ContentNegotiation) { json() } })
+
+    @Test fun authorizationUrlHasScopeOfflineConsentAndState() {
+        val url = api { respond("{}", HttpStatusCode.OK, jsonHeaders) }.authorizationUrl("st8")
+        assertTrue(url.startsWith("https://accounts.google.com/o/oauth2/v2/auth"))
+        assertTrue(url.contains("access_type=offline") && url.contains("prompt=consent") && url.contains("state=st8"))
+        assertTrue(url.contains("calendar")) // scope present (URL-encoded)
+    }
+
+    @Test fun exchangeCodeParsesTokens() = runBlocking {
+        val tokens = api { respond("""{"access_token":"AT","refresh_token":"RT","expires_in":3600}""", HttpStatusCode.OK, jsonHeaders) }
+            .exchangeCode("auth-code")
+        assertEquals("AT", tokens.accessToken); assertEquals("RT", tokens.refreshToken)
+    }
+
+    @Test fun accountEmailReadsPrimaryCalendarId() = runBlocking {
+        assertEquals("me@gmail.com",
+            api { respond("""{"id":"me@gmail.com"}""", HttpStatusCode.OK, jsonHeaders) }.accountEmail("AT"))
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/data/repositories/ConnectedCalendarRepositoryTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/repositories/ConnectedCalendarRepositoryTest.kt
@@ -40,6 +40,14 @@ class ConnectedCalendarRepositoryTest {
         assertTrue(repo.googleCalendars().isEmpty())
     }
 
+    @Test fun setBookingTargetWithUnknownIdLeavesCurrentTargetIntact() = runBlocking {
+        val a = google("a@x.com"); val b = google("b@x.com"); repo.add(a); repo.add(b)
+        repo.setBookingTarget(a.id)
+        assertEquals("a@x.com", repo.bookingTarget()?.accountEmail)
+        repo.setBookingTarget(java.util.UUID.randomUUID()) // unknown id — must be a no-op
+        assertEquals("a@x.com", repo.bookingTarget()?.accountEmail)
+    }
+
     @Test fun googleCalendarsExcludesSeededInMemoryRow() = runBlocking {
         assertEquals("IN_MEMORY", repo.default().provider) // seed still present
         assertTrue(repo.googleCalendars().isEmpty())

--- a/time-matcher/src/test/kotlin/io/vladar107/data/repositories/ConnectedCalendarRepositoryTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/repositories/ConnectedCalendarRepositoryTest.kt
@@ -1,0 +1,47 @@
+package io.vladar107.data.repositories
+
+import io.vladar107.data.persistence.Db
+import io.vladar107.domain.booking.ConnectedCalendar
+import kotlinx.coroutines.runBlocking
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ConnectedCalendarRepositoryTest {
+    private lateinit var repo: ExposedConnectedCalendarRepository
+    @BeforeTest fun setup() { Db.init("jdbc:h2:mem:cc-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"); repo = ExposedConnectedCalendarRepository() }
+
+    private fun google(email: String) = ConnectedCalendar(UUID.randomUUID(), email, "GOOGLE", email, "primary", "rt-$email")
+
+    @Test fun firstGoogleIsNotAutoTargetAtRepoLevel() = runBlocking {
+        val c = google("a@x.com"); repo.add(c)
+        assertEquals(listOf("a@x.com"), repo.googleCalendars().map { it.accountEmail })
+        assertNull(repo.bookingTarget()) // repo.add stores isBookingTarget as given (false here)
+    }
+
+    @Test fun setBookingTargetIsExclusiveAmongGoogleRows() = runBlocking {
+        val a = google("a@x.com"); val b = google("b@x.com"); repo.add(a); repo.add(b)
+        repo.setBookingTarget(a.id)
+        assertEquals("a@x.com", repo.bookingTarget()?.accountEmail)
+        repo.setBookingTarget(b.id)
+        assertEquals("b@x.com", repo.bookingTarget()?.accountEmail)
+        assertEquals(1, repo.googleCalendars().count { it.isBookingTarget })
+    }
+
+    @Test fun removeTargetAutoPromotesAnotherGoogleRow() = runBlocking {
+        val a = google("a@x.com"); val b = google("b@x.com"); repo.add(a); repo.add(b)
+        repo.setBookingTarget(a.id); repo.remove(a.id)
+        assertEquals("b@x.com", repo.bookingTarget()?.accountEmail) // promoted
+        repo.remove(b.id)
+        assertNull(repo.bookingTarget())
+        assertTrue(repo.googleCalendars().isEmpty())
+    }
+
+    @Test fun googleCalendarsExcludesSeededInMemoryRow() = runBlocking {
+        assertEquals("IN_MEMORY", repo.default().provider) // seed still present
+        assertTrue(repo.googleCalendars().isEmpty())
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/data/telegram/TelegramApiTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/telegram/TelegramApiTest.kt
@@ -1,0 +1,44 @@
+package io.vladar107.data.telegram
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TelegramApiTest {
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+    private fun client(handler: io.ktor.client.engine.mock.MockRequestHandler) =
+        HttpClient(MockEngine(handler)) { install(ContentNegotiation) { json() } }
+
+    @Test fun getUpdatesParsesMessageAndCallback() = runBlocking {
+        val body = """{"ok":true,"result":[
+          {"update_id":1,"message":{"message_id":10,"from":{"id":42},"chat":{"id":42},"text":"/connect"}},
+          {"update_id":2,"callback_query":{"id":"cb1","from":{"id":42},"data":"remove:abc"}}]}"""
+        val api = TelegramApi("TOK", client { respond(body, HttpStatusCode.OK, jsonHeaders) })
+        val updates = api.getUpdates(0)
+        assertEquals(2, updates.size)
+        assertEquals("/connect", updates[0].message?.text)
+        assertEquals("remove:abc", updates[1].callbackQuery?.data)
+    }
+
+    @Test fun sendMessagePostsChatIdTextAndInlineKeyboard() = runBlocking {
+        var captured = ""
+        val api = TelegramApi("TOK", client { req ->
+            if (req.url.toString().contains("/sendMessage")) captured = (req.body as io.ktor.http.content.TextContent).text
+            respond("""{"ok":true,"result":{}}""", HttpStatusCode.OK, jsonHeaders) })
+        api.sendMessage(42, "hello", listOf(listOf(TgButton("Set ★", callbackData = "target:1"), TgButton("Connect", url = "https://h/x"))))
+        assertTrue(captured.contains("\"chat_id\":42"))
+        assertTrue(captured.contains("hello"))
+        assertTrue(captured.contains("inline_keyboard"))
+        assertTrue(captured.contains("callback_data") && captured.contains("target:1"))
+        assertTrue(captured.contains("\"url\":\"https://h/x\""))
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/data/telegram/TelegramApiTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/data/telegram/TelegramApiTest.kt
@@ -11,6 +11,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TelegramApiTest {
@@ -40,5 +41,7 @@ class TelegramApiTest {
         assertTrue(captured.contains("inline_keyboard"))
         assertTrue(captured.contains("callback_data") && captured.contains("target:1"))
         assertTrue(captured.contains("\"url\":\"https://h/x\""))
+        assertFalse(captured.contains("\"callback_data\":null"))
+        assertFalse(captured.contains("\"url\":null"))
     }
 }

--- a/time-matcher/src/test/kotlin/io/vladar107/web/oauth/GoogleOAuthRoutesTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/web/oauth/GoogleOAuthRoutesTest.kt
@@ -1,0 +1,49 @@
+package io.vladar107.web.oauth
+
+import io.ktor.client.plugins.* // HttpRedirect off to observe 302
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import io.vladar107.module
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ConnectStateStoreTest {
+    private fun store(now: String) = ConnectStateStore(Clock.fixed(Instant.parse(now), ZoneId.of("UTC")))
+    @Test fun createThenConsumeReturnsChatIdOnce() {
+        val s = store("2030-01-01T00:00:00Z"); val nonce = s.create(42)
+        assertEquals(42L, s.consume(nonce)); assertEquals(null, s.consume(nonce)) // single-use
+    }
+    @Test fun unknownStateIsNull() { assertEquals(null, store("2030-01-01T00:00:00Z").consume("nope")) }
+}
+
+class GoogleOAuthRoutesTest {
+    private fun cfg() = MapApplicationConfig(
+        "db.url" to "jdbc:h2:mem:oauth-${java.util.UUID.randomUUID()};DB_CLOSE_DELAY=-1",
+        "calendar.provider" to "google",
+        "google.clientId" to "cid", "google.clientSecret" to "sec",
+        "oauth.redirectBaseUrl" to "http://localhost:8080")
+
+    @Test fun startRedirectsToGoogleConsent() = testApplication {
+        environment { config = cfg() }; application { module() }
+        val client = createClient { followRedirects = false }
+        val resp = client.get("/oauth/google/start?state=abc")
+        assertEquals(HttpStatusCode.Found, resp.status)
+        val location = resp.headers["Location"] ?: ""
+        assertTrue(location.startsWith("https://accounts.google.com/o/oauth2/v2/auth"))
+        assertTrue(location.contains("state=abc") && location.contains("access_type=offline") && location.contains("prompt=consent"))
+    }
+
+    @Test fun callbackWithInvalidStateIs400() = testApplication {
+        environment { config = cfg() }; application { module() }
+        val resp = createClient { followRedirects = false }.get("/oauth/google/callback?code=x&state=bogus")
+        assertEquals(HttpStatusCode.BadRequest, resp.status)
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/web/oauth/GoogleOAuthRoutesTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/web/oauth/GoogleOAuthRoutesTest.kt
@@ -39,6 +39,8 @@ class GoogleOAuthRoutesTest {
         val location = resp.headers["Location"] ?: ""
         assertTrue(location.startsWith("https://accounts.google.com/o/oauth2/v2/auth"))
         assertTrue(location.contains("state=abc") && location.contains("access_type=offline") && location.contains("prompt=consent"))
+        assertTrue(location.contains("redirect_uri="))
+        assertTrue(location.contains("calendar"))
     }
 
     @Test fun callbackWithInvalidStateIs400() = testApplication {

--- a/time-matcher/src/test/kotlin/io/vladar107/web/telegram/TelegramBotTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/web/telegram/TelegramBotTest.kt
@@ -1,0 +1,66 @@
+package io.vladar107.web.telegram
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import io.vladar107.application.booking.ConnectGoogleCalendarCommand
+import io.vladar107.data.telegram.*
+import io.vladar107.infrastructure.CommandProvider
+import io.vladar107.infrastructure.QueryProvider
+import io.vladar107.module
+import io.vladar107.web.oauth.ConnectStateStore
+import kotlinx.coroutines.runBlocking
+import java.time.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TelegramBotTest {
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+    private val sent = mutableListOf<String>()
+    private fun api() = TelegramApi("TOK", HttpClient(MockEngine { req ->
+        if (req.url.toString().contains("/sendMessage")) sent += (req.body as io.ktor.http.content.TextContent).text
+        respond("""{"ok":true,"result":{}}""", HttpStatusCode.OK, jsonHeaders)
+    }) { install(ContentNegotiation) { json() } })
+    private fun msg(uid: Long, text: String) = TgUpdate(1, message = TgMessage(10, TgUser(uid), TgChat(uid), text))
+
+    @Test fun nonHostSenderIsIgnored() = testApplication {
+        environment { config = MapApplicationConfig("db.url" to "jdbc:h2:mem:bot1-${java.util.UUID.randomUUID()};DB_CLOSE_DELAY=-1") }
+        lateinit var app: Application; application { app = this; module() }
+        startApplication()
+        val bot = TelegramBot(api(), hostUserId = 42, ConnectStateStore(Clock.systemUTC()), CommandProvider(app), QueryProvider(app), "http://localhost:8080")
+        bot.handle(msg(999, "/connect"))
+        assertTrue(sent.isEmpty())
+    }
+
+    @Test fun connectSendsAStartLinkWithState() = testApplication {
+        environment { config = MapApplicationConfig("db.url" to "jdbc:h2:mem:bot2-${java.util.UUID.randomUUID()};DB_CLOSE_DELAY=-1") }
+        lateinit var app: Application; application { app = this; module() }
+        startApplication()
+        val bot = TelegramBot(api(), 42, ConnectStateStore(Clock.systemUTC()), CommandProvider(app), QueryProvider(app), "http://localhost:8080")
+        bot.handle(msg(42, "/connect"))
+        assertEquals(1, sent.size)
+        assertTrue(sent[0].contains("/oauth/google/start?state="))
+    }
+
+    @Test fun calendarsListsConnectedWithStarAndButtons() = testApplication {
+        environment { config = MapApplicationConfig("db.url" to "jdbc:h2:mem:bot3-${java.util.UUID.randomUUID()};DB_CLOSE_DELAY=-1") }
+        lateinit var app: Application; application { app = this; module() }
+        startApplication()
+        // seed two connected calendars through the real use case
+        CommandProvider(app).run(ConnectGoogleCalendarCommand("a@x.com", "primary", "rt1"))
+        CommandProvider(app).run(ConnectGoogleCalendarCommand("b@x.com", "primary", "rt2"))
+        val bot = TelegramBot(api(), 42, ConnectStateStore(Clock.systemUTC()), CommandProvider(app), QueryProvider(app), "http://localhost:8080")
+        bot.handle(msg(42, "/calendars"))
+        assertEquals(1, sent.size)
+        assertTrue(sent[0].contains("a@x.com") && sent[0].contains("b@x.com"))
+        assertTrue(sent[0].contains("★"))            // ★ marks the target (a@x.com, first connected)
+        assertTrue(sent[0].contains("target:") && sent[0].contains("remove:")) // inline buttons
+    }
+}

--- a/time-matcher/src/test/kotlin/io/vladar107/web/telegram/TelegramBotTest.kt
+++ b/time-matcher/src/test/kotlin/io/vladar107/web/telegram/TelegramBotTest.kt
@@ -15,7 +15,6 @@ import io.vladar107.infrastructure.CommandProvider
 import io.vladar107.infrastructure.QueryProvider
 import io.vladar107.module
 import io.vladar107.web.oauth.ConnectStateStore
-import kotlinx.coroutines.runBlocking
 import java.time.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,10 +23,10 @@ import kotlin.test.assertTrue
 class TelegramBotTest {
     private val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
     private val sent = mutableListOf<String>()
-    private fun api() = TelegramApi("TOK", HttpClient(MockEngine { req ->
+    private fun api(): TelegramApi { sent.clear(); return TelegramApi("TOK", HttpClient(MockEngine { req ->
         if (req.url.toString().contains("/sendMessage")) sent += (req.body as io.ktor.http.content.TextContent).text
         respond("""{"ok":true,"result":{}}""", HttpStatusCode.OK, jsonHeaders)
-    }) { install(ContentNegotiation) { json() } })
+    }) { install(ContentNegotiation) { json() } }) }
     private fun msg(uid: Long, text: String) = TgUpdate(1, message = TgMessage(10, TgUser(uid), TgChat(uid), text))
 
     @Test fun nonHostSenderIsIgnored() = testApplication {


### PR DESCRIPTION
## Phase 2d (Slice 1) — Host-admin Telegram bot: connect & manage Google Calendars

Replaces the manual OAuth-Playground refresh-token copy-paste with a **host-only Telegram bot** as the management surface, and moves calendar credentials from env config into the database so multiple Google calendars can be connected. Reuses the existing CQRS use cases and the pure availability engine unchanged — this is an inbound-adapter + credential-plumbing change, no new domain logic, **no new dependencies** (Telegram is the raw Bot API over the existing Ktor client).

### What you can do
- DM the bot **`/connect`** → tap a link → approve once in the browser → the app captures and stores the refresh token itself (no Playground, no copy-paste).
- **`/calendars`** → list connected accounts, the booking target marked **★**, with inline **[Set ★] [Remove 🗑]** buttons.
- Availability now reflects **busy across all connected calendars**; new bookings are written to the single **★ booking-target** calendar.

### How it works
- **Bot** (`web/telegram/`): host-only (`TELEGRAM_HOST_USER_ID`), long-polling `getUpdates` loop that starts only when `TELEGRAM_BOT_TOKEN` is set; a `TelegramApi` (`data/telegram/`) wraps the raw Bot API.
- **Connect flow** (`web/oauth/`): `/connect` mints a single-use, 10-min state nonce (shared `ConnectStateStore`) → `GET /oauth/google/start` 302 → Google consent → `GET /oauth/google/callback` validates state, exchanges the code, stores the calendar via `ConnectGoogleCalendarCommand`, best-effort-notifies the bot.
- **Data** (migration `V2`): `connected_calendar` gains `account_email`, `external_calendar_id`, `refresh_token`, `is_booking_target`. Repo gains `googleCalendars()`/`bookingTarget()`/`add()`/`remove()` (auto-promotes a new target)/`setBookingTarget()`.
- **Google adapters**: now repo-backed and multi-calendar — per-refresh-token `GoogleTokenManager`, `GoogleCalendarProvider` unions busy across all connected calendars, `GoogleCalendarWriter` writes to the booking target.
- **Error codes** stay distinct: slot taken → **409**, calendar backend error → **502**, no booking calendar connected → **503**.
- Retired env: `GOOGLE_REFRESH_TOKEN` / `GOOGLE_CALENDAR_ID`. New: `OAUTH_REDIRECT_BASE_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_HOST_USER_ID`. Setup guide rewritten (Web-app OAuth client + redirect URI; connect-via-bot section).

### Testing
- Integration-leaning, happy path + tricky edges: repo round-trips (exclusive target, auto-promote, unknown-id no-op), connect use cases (first→target), multi-calendar busy **union** + write-to-target + no-target→503, Telegram client (null-omission invariant), OAuth (`authorizationUrl`/`exchangeCode`/`accountEmail` via MockEngine; route redirect + invalid-state→400), and bot dispatch (auth gate, `/connect` link, `/calendars` ★ + buttons) as a real integration test (live use cases + H2 + MockEngine capture).
- `./gradlew clean build` green; all pre-existing in-memory suites stay green.
- **Manual-verification gap (explicit):** the live `getUpdates` loop, a real BotFather bot, and a real Google connect/book round-trip are verified by hand.

### Reviewed
Whole-branch review: **ready to merge**, 0 Critical / 0 Important blocking. Per-task + final-review hardening already applied (deterministic `default()`, structured 502 on malformed rows, best-effort notify, unconditional shared state store, documented OAuth state pass-through). Deferred backlog: per-calendar fault isolation in the busy union; `HttpClient` shutdown lifecycle; a `"GOOGLE"` constant.

### Out of scope (later)
Event-type & schedule management via the bot · reschedule/cancel · sub-calendar selection within an account · token encryption-at-rest · webhook/public-URL deployment.

> Note: independent of the open booking-page PR; both touch `Application.module()`, so whichever merges second needs a trivial rebase.
